### PR TITLE
Stripe updates

### DIFF
--- a/apiary-sources/data-structures/RestError.md
+++ b/apiary-sources/data-structures/RestError.md
@@ -3,8 +3,5 @@
 + message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
 + messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
 
-## StripeRestError (object)
-+ statusCode (number) - the HTTP status code.
-+ message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
-+ messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
+## StripeRestError (RestError)
 + stripeError (object) - When using the `stripe` rail: the full error response from Stripe in case of an error charging a credit card.

--- a/apiary-sources/data-structures/RestError.md
+++ b/apiary-sources/data-structures/RestError.md
@@ -2,3 +2,9 @@
 + statusCode (number) - the HTTP status code.
 + message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
 + messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
+
+## StripeRestError (object)
++ statusCode (number) - the HTTP status code.
++ message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
++ messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
++ stripeError (object) - When using the `stripe` rail: the full error response from Stripe in case of an error charging a credit card.

--- a/apiary-sources/data-structures/TransactionParty.md
+++ b/apiary-sources/data-structures/TransactionParty.md
@@ -1,26 +1,17 @@
-## TransactionParty (object)
-+ rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`, `internal`]. Must be used in combination with one of the following identifiers.
-+ code (string) - `lightrail`: the code of a Gift Card or Promotion.
-+ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
-+ valueId (string) - `lightrail`: a Value's ID.
-+ source (string) - `stripe`: a tokenized credit card for Stripe.  
-+ customer (string) - `stripe`: a Stripe customer ID (uses customer's default source).  
-+ maxAmount (number) - `stripe`: the maximum amount that can be charged to the given Stripe source.  
-+ id (string) - `internal`: the ID of the internal value.
-+ balance (number) - `internal`: the amount of internal value stored.
-+ beforeLightrail (boolean) - `internal`: if true this value is applied before Lightrail Values, otherwise it will be applied after.
-
 ## LightrailTransactionParty (object)
 + rail (string) - The payment rail: `lightrail`. Must be used in combination with one of the following identifiers.
 + code (string) - `lightrail`: the code of a Gift Card or Promotion.
 + contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
 + valueId (string) - `lightrail`: a Value's ID.
 
-## StripeOrLightrailTransactionParty (object)
+## StripeOrLightrailTransactionParty (LightrailTransactionParty)
 + rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`]. Must be used in combination with one of the following identifiers.
-+ code (string) - `lightrail`: the code of a Gift Card or Promotion.
-+ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
-+ valueId (string) - `lightrail`: a Value's ID.
 + source (string) - `stripe`: a tokenized credit card for Stripe.  
 + customer (string) - `stripe`: a Stripe customer ID (uses customer's default source).  
 + maxAmount (number) - `stripe`: the maximum amount that can be charged to the given Stripe source.  
+
+## TransactionParty (StripeOrLightrailTransactionParty)
++ rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`, `internal`]. Must be used in combination with one of the following identifiers.
++ id (string) - `internal`: the ID of the internal value.
++ balance (number) - `internal`: the amount of internal value stored.
++ beforeLightrail (boolean) - `internal`: if true this value is applied before Lightrail Values, otherwise it will be applied after.

--- a/apiary-sources/data-structures/TransactionParty.md
+++ b/apiary-sources/data-structures/TransactionParty.md
@@ -9,3 +9,18 @@
 + id (string) - `internal`: the ID of the internal value.
 + balance (number) - `internal`: the amount of internal value stored.
 + beforeLightrail (boolean) - `internal`: if true this value is applied before Lightrail Values, otherwise it will be applied after.
+
+## LightrailTransactionParty (object)
++ rail (string) - The payment rail: `lightrail`. Must be used in combination with one of the following identifiers.
++ code (string) - `lightrail`: the code of a Gift Card or Promotion.
++ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
++ valueId (string) - `lightrail`: a Value's ID.
+
+## StripeOrLightrailTransactionParty (object)
++ rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`]. Must be used in combination with one of the following identifiers.
++ code (string) - `lightrail`: the code of a Gift Card or Promotion.
++ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
++ valueId (string) - `lightrail`: a Value's ID.
++ source (string) - `stripe`: a tokenized credit card for Stripe.  
++ customer (string) - `stripe`: a Stripe customer ID (uses customer's default source).  
++ maxAmount (number) - `stripe`: the maximum amount that can be charged to the given Stripe source.  

--- a/apiary-sources/endpoints/transactions-checkout.md
+++ b/apiary-sources/endpoints/transactions-checkout.md
@@ -73,7 +73,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
 + Response 422 (application/json)
 
-    Stripe minimum charge error: Stripe will not process charges for less than $0.50 USD (or equivalent). This error can be triggered in a split tender transaction if the customer does not have quite enough balance in their account or on their gift card. You may wish to handle this error by asking your customer to top up their account balance, or if the customer is using a gift card, you may wish to forgive the $0.50. 
+    Stripe minimum charge error: Stripe will not process charges for less than $0.50 USD (or equivalent). This error can be triggered in a split tender transaction if the customer does not have quite enough balance in their account or on their gift card. You may wish to handle this error by asking your customer to top up their account balance, or by adding a "minimum credit card amount fee" line item to the order that covers the difference. 
 
     + Body
 

--- a/apiary-sources/endpoints/transactions-checkout.md
+++ b/apiary-sources/endpoints/transactions-checkout.md
@@ -2,7 +2,9 @@
 
 The checkout endpoint is used to collect all payment for a purchase. It will debit funds from Lightrail and also charge credit cards through Stripe. Your Stripe account must be connected to Lightrail in order for Lightrail to make charges on your behalf. 
 
-Lightrail and Stripe payment sources are referred to as the payment rails `lightrail` and `stripe` respectively. There is also an `internal` payment rail which can be used to represent any other payment source. This is intended a stop-gap solution to support transitioning from legacy systems.    
+Lightrail and Stripe payment sources are referred to as the payment rails `lightrail` and `stripe` respectively. There is also an `internal` payment rail which can be used to represent any other payment source. This is intended as a stop-gap solution to support transitioning from legacy systems.
+
+Error responses: If using the `stripe` rail, it is possible for checkout transactions to fail for reasons outside of Lightrail's control, such as an invalid card token or a card being declined. Stripe errors will be passed on in full under the `stripeError` key in the response. 
 
 + Request (application/json)
     
@@ -12,11 +14,10 @@ Lightrail and Stripe payment sources are referred to as the payment rails `light
         - 1x $1.99 chocolate bar  (5% tax rate)
         - 1x $3.49 shipping (0% tax rate)
     - Payment Sources:
-        - Contact with prepaid account, and a sock and chocolate bar promotion.
-            - Account has $20.
+        - Contact with prepaid account and a chocolate bar promotion.
+            - Account has $10.
             - Sock promo is for 20% off retail price of socks.
-            - Chocolate bar promo is a $0.50 credit towards the purchase of a chocolate bar.
-        - Generic code for 10% off orders over $5 (does not apply to shipping). 
+        - Credit card
     
     + Headers
     
@@ -48,7 +49,7 @@ Lightrail and Stripe payment sources are referred to as the payment rails `light
 
     You cannot checkout if the balance of all Values does not cover the `lineItems` and there is no credit card to charge (if `allowRemainder` is not `true`).
 
-    + Attributes (Transaction)
+    + Attributes (StripeRestError)
 
     + Body
 
@@ -57,3 +58,29 @@ Lightrail and Stripe payment sources are referred to as the payment rails `light
                 "message": "Insufficient balance for the transaction.",
                 "messageCode": "InsufficientBalance"
             }
+
++ Response 409 (application/json)
+
+    Idempotency error: you cannot create use a Transaction `id` more than once, for the same or a different Transaction request.
+
+    + Body
+
+            {
+                "statusCode": 409,
+                "message": "A Lightrail transaction with transactionId 'transac-12345' already exists.",
+                "messageCode": "TransactionExists"
+            }
+
++ Response 422 (application/json)
+
+    Stripe minimum charge error: Stripe will not process charges for less than $0.50 USD (or equivalent). This error can be triggered in a split tender transaction if the customer does not have quite enough balance in their account or on their gift card. You may wish to handle this error by asking your customer to top up their account balance, or if the customer is using a gift card, you may wish to forgive the $0.50. 
+
+    + Body
+
+            {
+                "statusCode": 409,
+                "message": "Failed to charge credit card: amount '25' for Stripe was too small.",
+                "messageCode": "StripeAmountTooSmall",
+                "stripeError": {...}
+            }
+

--- a/apiary-sources/endpoints/transactions-credit.md
+++ b/apiary-sources/endpoints/transactions-credit.md
@@ -10,7 +10,7 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
         
     + Attributes
         + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
-        + destination (TransactionParty, required) - The rail to credit.  Only `lightrail` rails that refer to a specific Value are supported.
+        + destination (LightrailTransactionParty, required) - The rail to credit.  Only `lightrail` rails that refer to a specific Value are supported.
         + amount (number, required) - The amount to credit, > 0.
         + uses (number, optional) - The number of uses to add.  Defaults to 0.
         + currency (string, required) - {{currency.code}}
@@ -24,7 +24,7 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
     
 + Response 201 (application/json)
 
-    + Attributes (Transaction)
+    + Attributes (RestError)
 
     + Body
 

--- a/apiary-sources/endpoints/transactions-credit.md
+++ b/apiary-sources/endpoints/transactions-credit.md
@@ -1,6 +1,6 @@
 ### Credit [POST /transactions/credit]
 
-Credit (add to) a payment destination.  Currently only the `lightrail` rail is supported.
+Credit (add an amount to) a Lightrail payment destination.
 
 + Request (application/json)
 

--- a/apiary-sources/endpoints/transactions-debit.md
+++ b/apiary-sources/endpoints/transactions-debit.md
@@ -10,7 +10,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
         
     + Attributes
         + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
-        + source (TransactionParty, required) - The rail to debit.  Only `lightrail` rails that refer to a specific Value are supported.
+        + source (LightrailTransactionParty, required) - The rail to debit.  Only `lightrail` rails that refer to a specific Value are supported.
         + amount (number, required) - The amount to debit, > 0.
         + uses (number, optional) - The number of uses to remove.  Defaults to 0.
         + currency (string, required) - {{currency.code}}
@@ -35,7 +35,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     You cannot debit a Value by more balance than is available (if `allowRemainder` is not `true`).
 
-    + Attributes (Transaction)
+    + Attributes (RestError)
 
     + Body
 

--- a/apiary-sources/endpoints/transactions-debit.md
+++ b/apiary-sources/endpoints/transactions-debit.md
@@ -1,6 +1,6 @@
 ### Debit [POST /transactions/debit]
 
-Debit (remove from) a payment source.  Currently only the `lightrail` rail is supported.
+Debit (remove an amount from) a Lightrail payment source.
 
 + Request (application/json)
 

--- a/apiary-sources/endpoints/transactions-transfer.md
+++ b/apiary-sources/endpoints/transactions-transfer.md
@@ -1,6 +1,6 @@
 ### Transfer [POST /transactions/transfer]
 
-Transfer value between a payment source and a payment destination.  Currently only the `lightrail` rail is supported.
+Transfer value between a payment source and a payment destination.  Currently the `lightrail` and `stripe` rails are supported as `source`s and the `lightrail` rail is supported as a destination.
 
 + Request (application/json)
 
@@ -10,8 +10,8 @@ Transfer value between a payment source and a payment destination.  Currently on
 
     + Attributes
         + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
-        + source (TransactionParty, required) - {{transaction.source}}
-        + destination (TransactionParty, required) - {{transaction.destination}}
+        + source (StripeOrLightrailTransactionParty, required) - {{transaction.source}}
+        + destination (LightrailTransactionParty, required) - {{transaction.destination}}
         + amount (number, required) - The amount to transfer, > 0.
         + currency (string, required) - {{currency.code}}
         + simulate (boolean, optional) - {{transaction.simulate}}
@@ -44,7 +44,7 @@ Transfer value between a payment source and a payment destination.  Currently on
 
     You cannot transfer from a Value more balance than is available (if `allowRemainder` is not `true`).
 
-    + Attributes (Transaction)
+    + Attributes (StripeRestError)
 
     + Body
 

--- a/apiary-sources/endpoints/transactions-transfer.md
+++ b/apiary-sources/endpoints/transactions-transfer.md
@@ -1,6 +1,6 @@
 ### Transfer [POST /transactions/transfer]
 
-Transfer value between a payment source and a payment destination.  Currently the `lightrail` and `stripe` rails are supported as `source`s and the `lightrail` rail is supported as a destination.
+Transfer value from a Lightrail or Stripe payment source to a Lightrail payment destination.
 
 + Request (application/json)
 

--- a/apiary-sources/requests.json
+++ b/apiary-sources/requests.json
@@ -151,7 +151,8 @@
       "body": {
         "id": "{UUID()}",
         "currency": "USD",
-        "balance": 2000
+        "balance": 1000,
+        "contactId": "{REQUEST_REPLACEMENT:createContact1.body.id}"
       }
     },
     {
@@ -186,7 +187,8 @@
         "valueRule": {
           "rule": "currentLineItem.lineTotal.subtotal * 0.20",
           "explanation": "20% off socks"
-        }
+        },
+        "contactId": "{REQUEST_REPLACEMENT:createContact1.body.id}"
       }
     },
     {
@@ -198,15 +200,11 @@
         "sources": [
           {
             "rail": "lightrail",
-            "valueId": "{REQUEST_REPLACEMENT:createValue1ForCheckoutExample.body.id}"
+            "contactId": "{REQUEST_REPLACEMENT:createContact1.body.id}"
           },
           {
-            "rail": "lightrail",
-            "valueId": "{REQUEST_REPLACEMENT:createValue2ForCheckoutExample.body.id}"
-          },
-          {
-            "rail": "lightrail",
-            "valueId": "{REQUEST_REPLACEMENT:createValue3ForCheckoutExample.body.id}"
+            "rail": "stripe",
+            "source": "tok_visa"
           }
         ],
         "lineItems": [

--- a/apiary-sources/sections/errors.md
+++ b/apiary-sources/sections/errors.md
@@ -9,7 +9,7 @@ Lightrail uses the following HTTP status codes to indicate an error:
 | 403  | The operation is not allowed for the given authentication. |
 | 404  | The resource was not found.  eg: There is no Contact for the given ID. |
 | 409  | The operation could not be performed because of the state of the system.  eg: There is not enough balance for a Transaction to complete. |
-| 422  | The request was understood but has a logical problem.  eg: Attempting to credit a negative amount. |
+| 422  | The request was understood but has a logical problem.  eg: Attempting to credit a negative amount. If using the `stripe` payment rail, most Stripe errors will result in a `422`. |
 | 429  | Too many requests in a given amount of time. |
 | 500  | Internal server error.  Please [contact us](mailto:hello@lightrail.com) with details of your request and we'll look into it. |
 
@@ -20,6 +20,7 @@ Lightrail errors contain a JSON body with the following properties:
 | message     | yes            | English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates. |
 | statusCode  | yes            | The HTTP status code. |
 | messageCode | no             | A constant corresponding to the message.  This can be used to take action in response to the error. |
+| stripeError | no             | When using the `stripe` rail: the full error response from Stripe in case of an error charging a credit card. |
 
 An example:
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -81,7 +81,7 @@ Lightrail uses the following HTTP status codes to indicate an error:
 | 403  | The operation is not allowed for the given authentication. |
 | 404  | The resource was not found.  eg: There is no Contact for the given ID. |
 | 409  | The operation could not be performed because of the state of the system.  eg: There is not enough balance for a Transaction to complete. |
-| 422  | The request was understood but has a logical problem.  eg: Attempting to credit a negative amount. |
+| 422  | The request was understood but has a logical problem.  eg: Attempting to credit a negative amount. If using the `stripe` payment rail, most Stripe errors will result in a `422`. |
 | 429  | Too many requests in a given amount of time. |
 | 500  | Internal server error.  Please [contact us](mailto:hello@lightrail.com) with details of your request and we'll look into it. |
 
@@ -92,6 +92,7 @@ Lightrail errors contain a JSON body with the following properties:
 | message     | yes            | English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates. |
 | statusCode  | yes            | The HTTP status code. |
 | messageCode | no             | A constant corresponding to the message.  This can be used to take action in response to the error. |
+| stripeError | no             | When using the `stripe` rail: the full error response from Stripe in case of an error charging a credit card. |
 
 An example:
 
@@ -129,14 +130,14 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"89e55ef5-9a11-48f8-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
+            {"id":"221c75df-bd39-4a3a-8","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"89e55ef5-9a11-48f8-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-24T22:02:07.000Z","updatedDate":"2018-07-24T22:02:07.000Z"}
+            {"id":"221c75df-bd39-4a3a-8","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
 ### Get a Contact [GET /contacts/{id}]
 
 + Parameter
@@ -152,7 +153,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"89e55ef5-9a11-48f8-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-24T22:02:07.000Z","updatedDate":"2018-07-24T22:02:07.000Z"}
+            {"id":"221c75df-bd39-4a3a-8","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
 
 ### List Contacts [GET /contacts{?limit}{?id}{?tags}{?firstName}{?lastName}{?email}]
         
@@ -180,7 +181,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            [{"id":"1be4ca51-40dd-4feb-a","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-24T21:38:10.000Z","updatedDate":"2018-07-24T21:38:11.000Z"}]
+            [{"id":"0bd795f8-7f91-4df7-9","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-24T22:06:43.000Z","updatedDate":"2018-07-24T22:06:43.000Z"}]
 ### Update a Contact [PATCH /contacts/{id}]
             
 + Parameter
@@ -211,7 +212,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"89e55ef5-9a11-48f8-a","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-24T22:02:07.000Z","updatedDate":"2018-07-24T22:02:07.000Z"}
+            {"id":"221c75df-bd39-4a3a-8","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
 ### Delete a Contact [DELETE /contacts/{id}]
 
 + Parameter
@@ -279,7 +280,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            [{"id":"dc7d04c5-e92e-4d8f-b","currency":"USD","balance":500,"uses":null,"programId":"5a48dfc1-468d-4039-a","contactId":"89e55ef5-9a11-48f8-a","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}]
+            [{"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":"221c75df-bd39-4a3a-8","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}]
 ### Attach a Contact to a Value [POST /contacts/{id}/values/attach]
 
 + Parameter
@@ -296,7 +297,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"valueId":"dc7d04c5-e92e-4d8f-b"}
+            {"valueId":"8a3fd91b-c715-4927-8"}
     
 + Response 200 (application/json)
     
@@ -308,7 +309,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"dc7d04c5-e92e-4d8f-b","currency":"USD","balance":500,"uses":null,"programId":"5a48dfc1-468d-4039-a","contactId":"89e55ef5-9a11-48f8-a","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}
+            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":"221c75df-bd39-4a3a-8","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
 
 + Response 409 (application/json)
     
@@ -361,14 +362,14 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
         
     + Body
     
-            {"id":"dc7d04c5-e92e-4d8f-b","programId":"5a48dfc1-468d-4039-a","balance":500}
+            {"id":"8a3fd91b-c715-4927-8","programId":"28c238ef-d3cf-473e-b","balance":500}
     
 + Response 201 (application/json)
     + Attributes (Value)
 
     + Body
     
-            {"id":"dc7d04c5-e92e-4d8f-b","currency":"USD","balance":500,"uses":null,"programId":"5a48dfc1-468d-4039-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}
+            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
 ### Get a Value [GET /values/{id}{?showCode}]
 
 + Parameter
@@ -385,7 +386,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"dc7d04c5-e92e-4d8f-b","currency":"USD","balance":500,"uses":null,"programId":"5a48dfc1-468d-4039-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}
+            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
 
 ### List Values [GET /values{?limit}{?showCode}{?programId}{?currency}{?contactId}{?balance}{?uses}{?discount}{?active}{?frozen}{?canceled}{?preTax}{?startDate}{?endDate}{?createdDate}{?updatedDate}{?tags}]
         
@@ -503,7 +504,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
     
-            {"id":"dc7d04c5-e92e-4d8f-b","currency":"USD","balance":500,"uses":null,"programId":"5a48dfc1-468d-4039-a","contactId":"89e55ef5-9a11-48f8-a","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}
+            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":"221c75df-bd39-4a3a-8","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
 ### Delete a Value [DELETE /values/{id}]
 
 + Parameter
@@ -560,7 +561,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"118688e3-b061-4263-a","currency":"USD","balance":500,"uses":null,"programId":"5a48dfc1-468d-4039-a","contactId":null,"code":"\u2026PFM4","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T22:02:09.000Z","updatedDate":"2018-07-24T22:02:09.000Z"}
+            {"id":"a1e10b10-dee5-43d9-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":null,"code":"\u2026REAN","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:35.000Z","updatedDate":"2018-07-24T23:50:35.000Z"}
 
 ## Programs [/programs]
 
@@ -595,14 +596,14 @@ Programs are most commonly used to define and organize promotion campaigns. For 
         
     + Body
 
-            {"id":"5a48dfc1-468d-4039-a","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
+            {"id":"28c238ef-d3cf-473e-b","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"5a48dfc1-468d-4039-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}
+            {"id":"28c238ef-d3cf-473e-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
 ### Get a Program [GET /programs/promotions/{id}]
 
 + Parameter
@@ -618,7 +619,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-                {"id":"5a48dfc1-468d-4039-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}
+                {"id":"28c238ef-d3cf-473e-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
 
 ### List Programs [GET /programs{?limit}{?id}{?name}{?preTax}{?currency}{?tags}{?startDate}{?endDate}{?createdDate}{?updatedDate}]
         
@@ -686,7 +687,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
             
-            {"id":"5a48dfc1-468d-4039-a","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T22:02:08.000Z","updatedDate":"2018-07-24T22:02:08.000Z"}
+            {"id":"28c238ef-d3cf-473e-b","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
 ### Delete a Program [DELETE /programs/{id}]
 
 + Parameter
@@ -818,7 +819,9 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
 The checkout endpoint is used to collect all payment for a purchase. It will debit funds from Lightrail and also charge credit cards through Stripe. Your Stripe account must be connected to Lightrail in order for Lightrail to make charges on your behalf. 
 
-Lightrail and Stripe payment sources are referred to as the payment rails `lightrail` and `stripe` respectively. There is also an `internal` payment rail which can be used to represent any other payment source. This is intended a stop-gap solution to support transitioning from legacy systems.    
+Lightrail and Stripe payment sources are referred to as the payment rails `lightrail` and `stripe` respectively. There is also an `internal` payment rail which can be used to represent any other payment source. This is intended as a stop-gap solution to support transitioning from legacy systems.
+
+Error responses: If using the `stripe` rail, it is possible for checkout transactions to fail for reasons outside of Lightrail's control, such as an invalid card token or a card being declined. Stripe errors will be passed on in full under the `stripeError` key in the response. 
 
 + Request (application/json)
     
@@ -828,11 +831,10 @@ Lightrail and Stripe payment sources are referred to as the payment rails `light
         - 1x $1.99 chocolate bar  (5% tax rate)
         - 1x $3.49 shipping (0% tax rate)
     - Payment Sources:
-        - Contact with prepaid account, and a sock and chocolate bar promotion.
-            - Account has $20.
+        - Contact with prepaid account and a chocolate bar promotion.
+            - Account has $10.
             - Sock promo is for 20% off retail price of socks.
-            - Chocolate bar promo is a $0.50 credit towards the purchase of a chocolate bar.
-        - Generic code for 10% off orders over $5 (does not apply to shipping). 
+        - Credit card
     
     + Headers
     
@@ -850,7 +852,7 @@ Lightrail and Stripe payment sources are referred to as the payment rails `light
         
     + Body 
     
-            {"id":"05cbd9e6-7d06-432c-b","sources":[{"rail":"lightrail","valueId":"b6e5c8c5-ed2f-456c-9"},{"rail":"lightrail","valueId":"42b7e259-7f1a-4f51-9"},{"rail":"lightrail","valueId":"3304d180-bd6b-445d-a"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
+            {"id":"1976c09c-07d5-4180-b","sources":[{"rail":"lightrail","contactId":"221c75df-bd39-4a3a-8"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
     
 + Response 201 (application/json)
 
@@ -858,13 +860,13 @@ Lightrail and Stripe payment sources are referred to as the payment rails `light
 
     + Body
     
-            {"id":"05cbd9e6-7d06-432c-b","transactionType":"checkout","currency":"USD","createdDate":"2018-07-24T22:02:09.000Z","totals":{"subtotal":1548,"tax":71,"discount":250,"payable":1369,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":149,"tax":7,"discount":50,"remainder":0,"payable":156}}],"steps":[{"rail":"lightrail","valueId":"3304d180-bd6b-445d-a","contactId":null,"code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"42b7e259-7f1a-4f51-9","contactId":null,"code":null,"balanceBefore":50,"balanceAfter":0,"balanceChange":-50},{"rail":"lightrail","valueId":"b6e5c8c5-ed2f-456c-9","contactId":null,"code":null,"balanceBefore":2000,"balanceAfter":631,"balanceChange":-1369}],"paymentSources":[{"rail":"lightrail","valueId":"b6e5c8c5-ed2f-456c-9"},{"rail":"lightrail","valueId":"42b7e259-7f1a-4f51-9"},{"rail":"lightrail","valueId":"3304d180-bd6b-445d-a"}],"metadata":null}
+            {"id":"1976c09c-07d5-4180-b","transactionType":"checkout","currency":"USD","createdDate":"2018-07-24T23:50:32.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"3ae128ae-4062-4aa0-8","contactId":"221c75df-bd39-4a3a-8","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"5b9e2163-48d5-476a-8","contactId":"221c75df-bd39-4a3a-8","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1CraH0CM9MOvFvZKuN73dOwG","charge":{"id":"ch_1CraH0CM9MOvFvZKuN73dOwG","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1CraH0CM9MOvFvZKe4QrKVSN","captured":true,"created":1532476234,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"1976c09c-07d5-4180-b","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"3ae128ae-4062-4aa0-8\"},{\"rail\":\"lightrail\",\"valueId\":\"5b9e2163-48d5-476a-8\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1CraH0CM9MOvFvZKuN73dOwG/refunds"},"review":null,"shipping":null,"source":{"id":"card_1CraH0CM9MOvFvZKGynLyHig","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"221c75df-bd39-4a3a-8"},{"rail":"stripe","source":"tok_visa","chargeId":"ch_1CraH0CM9MOvFvZKuN73dOwG"}],"metadata":null}
 
 + Response 409 (application/json)
 
     You cannot checkout if the balance of all Values does not cover the `lineItems` and there is no credit card to charge (if `allowRemainder` is not `true`).
 
-    + Attributes (Transaction)
+    + Attributes (StripeRestError)
 
     + Body
 
@@ -873,6 +875,32 @@ Lightrail and Stripe payment sources are referred to as the payment rails `light
                 "message": "Insufficient balance for the transaction.",
                 "messageCode": "InsufficientBalance"
             }
+
++ Response 409 (application/json)
+
+    Idempotency error: you cannot create use a Transaction `id` more than once, for the same or a different Transaction request.
+
+    + Body
+
+            {
+                "statusCode": 409,
+                "message": "A Lightrail transaction with transactionId 'transac-12345' already exists.",
+                "messageCode": "TransactionExists"
+            }
+
++ Response 422 (application/json)
+
+    Stripe minimum charge error: Stripe will not process charges for less than $0.50 USD (or equivalent). This error can be triggered in a split tender transaction if the customer does not have quite enough balance in their account or on their gift card. You may wish to handle this error by asking your customer to top up their account balance, or if the customer is using a gift card, you may wish to forgive the $0.50. 
+
+    + Body
+
+            {
+                "statusCode": 409,
+                "message": "Failed to charge credit card: amount '25' for Stripe was too small.",
+                "messageCode": "StripeAmountTooSmall",
+                "stripeError": {...}
+            }
+
 ### Debit [POST /transactions/debit]
 
 Debit (remove from) a payment source.  Currently only the `lightrail` rail is supported.
@@ -896,7 +924,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"aadc73b2-3f5e-4792-a","source":{"rail":"lightrail","valueId":"18834f88-f137-4291-8"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"1f6042c7-e4c9-4096-9","source":{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
     
 + Response 201 (application/json)
 
@@ -904,7 +932,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"aadc73b2-3f5e-4792-a","transactionType":"debit","currency":"USD","createdDate":"2018-07-24T22:02:08.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"18834f88-f137-4291-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"1f6042c7-e4c9-4096-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-24T23:50:31.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 + Response 409 (application/json)
 
@@ -941,7 +969,7 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
 
     + Body
 
-            {"id":"aad7f28e-678e-48a6-b","destination":{"rail":"lightrail","valueId":"18834f88-f137-4291-8"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"d15979ec-dbc9-4dda-b","destination":{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
     
 + Response 201 (application/json)
 
@@ -949,11 +977,11 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
 
     + Body
 
-            {"id":"aad7f28e-678e-48a6-b","transactionType":"credit","currency":"USD","createdDate":"2018-07-24T22:02:08.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"18834f88-f137-4291-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"d15979ec-dbc9-4dda-b","transactionType":"credit","currency":"USD","createdDate":"2018-07-24T23:50:31.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
 
 ### Transfer [POST /transactions/transfer]
 
-Transfer value between a payment source and a payment destination.  Currently only the `lightrail` rail is supported.
+Transfer value between a payment source and a payment destination.  Currently the `lightrail` and `stripe` rails are supported as `source`s and the `lightrail` rail is supported as a destination.
 
 + Request (application/json)
 
@@ -963,8 +991,8 @@ Transfer value between a payment source and a payment destination.  Currently on
 
     + Attributes
         + id (string, required) - ID for the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
-        + source (TransactionParty, required) - Supported rails: `["lightrail", "stripe"]`.
-        + destination (TransactionParty, required) - Only supported rail is `"lightrail"` and must it refer to a single Value.
+        + source (StripeOrLightrailTransactionParty, required) - Supported rails: `["lightrail", "stripe"]`.
+        + destination (LightrailTransactionParty, required) - Only supported rail is `"lightrail"` and must it refer to a single Value.
         + amount (number, required) - The amount to transfer, > 0.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + simulate (boolean, optional) - If true the transaction is simulated and no changes take place.  If the transaction is repeated with simulate=false it is not guaranteed to behave the same way as the underlying Values can change.
@@ -974,7 +1002,7 @@ Transfer value between a payment source and a payment destination.  Currently on
 
     + Body
 
-            {"id":"1110698a-cf72-4861-b","source":{"rail":"lightrail","valueId":"48b32d1a-e87a-496f-b"},"destination":{"rail":"lightrail","valueId":"14271630-45ea-4bf5-a"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"9f3c1bfb-c1c7-480d-8","source":{"rail":"lightrail","valueId":"0f15c587-8450-41d7-a"},"destination":{"rail":"lightrail","valueId":"f1c8e671-af44-4b43-a"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 201 (application/json)
 
@@ -991,13 +1019,13 @@ Transfer value between a payment source and a payment destination.  Currently on
 
     + Body
 
-            {"id":"1110698a-cf72-4861-b","transactionType":"transfer","currency":"USD","createdDate":"2018-07-24T22:02:10.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"48b32d1a-e87a-496f-b","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"14271630-45ea-4bf5-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"9f3c1bfb-c1c7-480d-8","transactionType":"transfer","currency":"USD","createdDate":"2018-07-24T23:50:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"0f15c587-8450-41d7-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"f1c8e671-af44-4b43-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 409 (application/json)
 
     You cannot transfer from a Value more balance than is available (if `allowRemainder` is not `true`).
 
-    + Attributes (Transaction)
+    + Attributes (StripeRestError)
 
     + Body
 
@@ -1021,7 +1049,7 @@ Transfer value between a payment source and a payment destination.  Currently on
 
     + Body
 
-            {"id":"aadc73b2-3f5e-4792-a","transactionType":"debit","currency":"USD","createdDate":"2018-07-24T22:02:08.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"18834f88-f137-4291-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"1f6042c7-e4c9-4096-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-24T23:50:31.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 ### List Transactions [GET /transactions{?limit}{?transactionType}{?createdDate}{?maxCreatedDate}]
 
@@ -1370,6 +1398,12 @@ A Currency is a unit of money in Lightrail.  It can be a standard currency such 
 + message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
 + messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
 
+## StripeRestError (object)
++ statusCode (number) - the HTTP status code.
++ message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
++ messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
++ stripeError (object) - When using the `stripe` rail: the full error response from Stripe in case of an error charging a credit card.
+
 ## Rule (object)
 + rule (string) - the Lightrail Rule text of the rule.
 + explanation (string) - a plain explanation of the rule seen by contacts.
@@ -1410,6 +1444,21 @@ A Currency is a unit of money in Lightrail.  It can be a standard currency such 
 + id (string) - `internal`: the ID of the internal value.
 + balance (number) - `internal`: the amount of internal value stored.
 + beforeLightrail (boolean) - `internal`: if true this value is applied before Lightrail Values, otherwise it will be applied after.
+
+## LightrailTransactionParty (object)
++ rail (string) - The payment rail: `lightrail`. Must be used in combination with one of the following identifiers.
++ code (string) - `lightrail`: the code of a Gift Card or Promotion.
++ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
++ valueId (string) - `lightrail`: a Value's ID.
+
+## StripeOrLightrailTransactionParty (object)
++ rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`]. Must be used in combination with one of the following identifiers.
++ code (string) - `lightrail`: the code of a Gift Card or Promotion.
++ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
++ valueId (string) - `lightrail`: a Value's ID.
++ source (string) - `stripe`: a tokenized credit card for Stripe.  
++ customer (string) - `stripe`: a Stripe customer ID (uses customer's default source).  
++ maxAmount (number) - `stripe`: the maximum amount that can be charged to the given Stripe source.  
 
 ## TransactionStep (object)
 A step taken as part of the transaction.

--- a/apiary.apib
+++ b/apiary.apib
@@ -130,14 +130,14 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
+            {"id":"32effdf9-d0b7-484b-b","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T15:50:44.000Z","updatedDate":"2018-07-25T15:50:44.000Z"}
+            {"id":"32effdf9-d0b7-484b-b","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T16:11:11.000Z","updatedDate":"2018-07-25T16:11:11.000Z"}
 ### Get a Contact [GET /contacts/{id}]
 
 + Parameter
@@ -153,7 +153,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T15:50:44.000Z","updatedDate":"2018-07-25T15:50:44.000Z"}
+            {"id":"32effdf9-d0b7-484b-b","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T16:11:11.000Z","updatedDate":"2018-07-25T16:11:11.000Z"}
 
 ### List Contacts [GET /contacts{?limit}{?id}{?tags}{?firstName}{?lastName}{?email}]
         
@@ -212,7 +212,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-25T15:50:44.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
+            {"id":"32effdf9-d0b7-484b-b","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-25T16:11:11.000Z","updatedDate":"2018-07-25T16:11:12.000Z"}
 ### Delete a Contact [DELETE /contacts/{id}]
 
 + Parameter
@@ -280,7 +280,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            [{"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}]
+            [{"id":"64cb7344-b3a4-4e0e-a","currency":"USD","balance":500,"uses":null,"programId":"ee256922-1d7c-4e81-9","contactId":"32effdf9-d0b7-484b-b","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T16:11:13.000Z","updatedDate":"2018-07-25T16:11:13.000Z"}]
 ### Attach a Contact to a Value [POST /contacts/{id}/values/attach]
 
 + Parameter
@@ -297,7 +297,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"valueId":"47c394da-66d3-4fe9-9"}
+            {"valueId":"64cb7344-b3a4-4e0e-a"}
     
 + Response 200 (application/json)
     
@@ -309,7 +309,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
+            {"id":"64cb7344-b3a4-4e0e-a","currency":"USD","balance":500,"uses":null,"programId":"ee256922-1d7c-4e81-9","contactId":"32effdf9-d0b7-484b-b","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T16:11:13.000Z","updatedDate":"2018-07-25T16:11:13.000Z"}
 
 + Response 409 (application/json)
     
@@ -362,14 +362,14 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
         
     + Body
     
-            {"id":"47c394da-66d3-4fe9-9","programId":"794b8a78-0595-4130-a","balance":500}
+            {"id":"64cb7344-b3a4-4e0e-a","programId":"ee256922-1d7c-4e81-9","balance":500}
     
 + Response 201 (application/json)
     + Attributes (Value)
 
     + Body
     
-            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
+            {"id":"64cb7344-b3a4-4e0e-a","currency":"USD","balance":500,"uses":null,"programId":"ee256922-1d7c-4e81-9","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T16:11:13.000Z","updatedDate":"2018-07-25T16:11:13.000Z"}
 ### Get a Value [GET /values/{id}{?showCode}]
 
 + Parameter
@@ -386,7 +386,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
+            {"id":"64cb7344-b3a4-4e0e-a","currency":"USD","balance":500,"uses":null,"programId":"ee256922-1d7c-4e81-9","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T16:11:13.000Z","updatedDate":"2018-07-25T16:11:13.000Z"}
 
 ### List Values [GET /values{?limit}{?showCode}{?programId}{?currency}{?contactId}{?balance}{?uses}{?discount}{?active}{?frozen}{?canceled}{?preTax}{?startDate}{?endDate}{?createdDate}{?updatedDate}{?tags}]
         
@@ -504,7 +504,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
     
-            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:46.000Z"}
+            {"id":"64cb7344-b3a4-4e0e-a","currency":"USD","balance":500,"uses":null,"programId":"ee256922-1d7c-4e81-9","contactId":"32effdf9-d0b7-484b-b","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T16:11:13.000Z","updatedDate":"2018-07-25T16:11:13.000Z"}
 ### Delete a Value [DELETE /values/{id}]
 
 + Parameter
@@ -561,7 +561,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"0f36f7c4-8c25-4840-b","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":null,"code":"\u2026ZCFJ","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:52.000Z","updatedDate":"2018-07-25T15:50:52.000Z"}
+            {"id":"5f9beea4-1be2-4b8b-b","currency":"USD","balance":500,"uses":null,"programId":"ee256922-1d7c-4e81-9","contactId":null,"code":"\u20269G6P","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T16:11:18.000Z","updatedDate":"2018-07-25T16:11:18.000Z"}
 
 ## Programs [/programs]
 
@@ -596,14 +596,14 @@ Programs are most commonly used to define and organize promotion campaigns. For 
         
     + Body
 
-            {"id":"794b8a78-0595-4130-a","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
+            {"id":"ee256922-1d7c-4e81-9","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"794b8a78-0595-4130-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
+            {"id":"ee256922-1d7c-4e81-9","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T16:11:12.000Z","updatedDate":"2018-07-25T16:11:12.000Z"}
 ### Get a Program [GET /programs/promotions/{id}]
 
 + Parameter
@@ -619,7 +619,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-                {"id":"794b8a78-0595-4130-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
+                {"id":"ee256922-1d7c-4e81-9","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T16:11:12.000Z","updatedDate":"2018-07-25T16:11:12.000Z"}
 
 ### List Programs [GET /programs{?limit}{?id}{?name}{?preTax}{?currency}{?tags}{?startDate}{?endDate}{?createdDate}{?updatedDate}]
         
@@ -687,7 +687,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
             
-            {"id":"794b8a78-0595-4130-a","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
+            {"id":"ee256922-1d7c-4e81-9","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T16:11:12.000Z","updatedDate":"2018-07-25T16:11:12.000Z"}
 ### Delete a Program [DELETE /programs/{id}]
 
 + Parameter
@@ -852,7 +852,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
         
     + Body 
     
-            {"id":"10ab73e9-0d54-4450-8","sources":[{"rail":"lightrail","contactId":"9fa9f457-0cb7-4f3b-9"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
+            {"id":"63d1178c-f2de-48d6-a","sources":[{"rail":"lightrail","contactId":"32effdf9-d0b7-484b-b"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
     
 + Response 201 (application/json)
 
@@ -860,7 +860,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
     + Body
     
-            {"id":"10ab73e9-0d54-4450-8","transactionType":"checkout","currency":"USD","createdDate":"2018-07-25T15:50:47.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"d191f939-fc2a-4f1a-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"7065d163-e9ff-4091-8","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1CrpGJCM9MOvFvZKEAkzlix4","charge":{"id":"ch_1CrpGJCM9MOvFvZKEAkzlix4","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1CrpGJCM9MOvFvZKbaf9MC0j","captured":true,"created":1532533851,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"10ab73e9-0d54-4450-8","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"d191f939-fc2a-4f1a-a\"},{\"rail\":\"lightrail\",\"valueId\":\"7065d163-e9ff-4091-8\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1CrpGJCM9MOvFvZKEAkzlix4/refunds"},"review":null,"shipping":null,"source":{"id":"card_1CrpGJCM9MOvFvZKzXgLpMgi","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"9fa9f457-0cb7-4f3b-9"},{"rail":"stripe","source":"tok_visa","chargeId":"ch_1CrpGJCM9MOvFvZKEAkzlix4"}],"metadata":null}
+            {"id":"63d1178c-f2de-48d6-a","transactionType":"checkout","currency":"USD","createdDate":"2018-07-25T16:11:14.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"a4b6fa8f-c335-4777-9","contactId":"32effdf9-d0b7-484b-b","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"55cb5797-1e55-48cf-a","contactId":"32effdf9-d0b7-484b-b","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1Crpa4CM9MOvFvZKlhgVLmyB","charge":{"id":"ch_1Crpa4CM9MOvFvZKlhgVLmyB","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1Crpa4CM9MOvFvZKQAwaa4bM","captured":true,"created":1532535076,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"63d1178c-f2de-48d6-a","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"a4b6fa8f-c335-4777-9\"},{\"rail\":\"lightrail\",\"valueId\":\"55cb5797-1e55-48cf-a\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1Crpa4CM9MOvFvZKlhgVLmyB/refunds"},"review":null,"shipping":null,"source":{"id":"card_1Crpa4CM9MOvFvZKQQJxjzPw","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"32effdf9-d0b7-484b-b"},{"rail":"stripe","source":"tok_visa","chargeId":"ch_1Crpa4CM9MOvFvZKlhgVLmyB"}],"metadata":null}
 
 + Response 409 (application/json)
 
@@ -890,7 +890,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
 + Response 422 (application/json)
 
-    Stripe minimum charge error: Stripe will not process charges for less than $0.50 USD (or equivalent). This error can be triggered in a split tender transaction if the customer does not have quite enough balance in their account or on their gift card. You may wish to handle this error by asking your customer to top up their account balance, or if the customer is using a gift card, you may wish to forgive the $0.50. 
+    Stripe minimum charge error: Stripe will not process charges for less than $0.50 USD (or equivalent). This error can be triggered in a split tender transaction if the customer does not have quite enough balance in their account or on their gift card. You may wish to handle this error by asking your customer to top up their account balance, or by adding a "minimum credit card amount fee" line item to the order that covers the difference. 
 
     + Body
 
@@ -903,7 +903,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
 ### Debit [POST /transactions/debit]
 
-Debit (remove from) a payment source.  Currently only the `lightrail` rail is supported.
+Debit (remove an amount from) a Lightrail payment source.
 
 + Request (application/json)
 
@@ -924,7 +924,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"bf44be20-4d66-4c8c-9","source":{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"4d0da706-e2d0-4a59-8","source":{"rail":"lightrail","valueId":"779ef54c-0264-4e39-8"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
     
 + Response 201 (application/json)
 
@@ -932,7 +932,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"bf44be20-4d66-4c8c-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T15:50:46.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"4d0da706-e2d0-4a59-8","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T16:11:13.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"779ef54c-0264-4e39-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 + Response 409 (application/json)
 
@@ -949,7 +949,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
             }
 ### Credit [POST /transactions/credit]
 
-Credit (add to) a payment destination.  Currently only the `lightrail` rail is supported.
+Credit (add an amount to) a Lightrail payment destination.
 
 + Request (application/json)
 
@@ -969,7 +969,7 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
 
     + Body
 
-            {"id":"dc64ecd3-5e03-4189-a","destination":{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"6461b649-9f4f-4ad9-9","destination":{"rail":"lightrail","valueId":"779ef54c-0264-4e39-8"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
     
 + Response 201 (application/json)
 
@@ -977,11 +977,11 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
 
     + Body
 
-            {"id":"dc64ecd3-5e03-4189-a","transactionType":"credit","currency":"USD","createdDate":"2018-07-25T15:50:46.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"6461b649-9f4f-4ad9-9","transactionType":"credit","currency":"USD","createdDate":"2018-07-25T16:11:13.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"779ef54c-0264-4e39-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
 
 ### Transfer [POST /transactions/transfer]
 
-Transfer value between a payment source and a payment destination.  Currently the `lightrail` and `stripe` rails are supported as `source`s and the `lightrail` rail is supported as a destination.
+Transfer value from a Lightrail or Stripe payment source to a Lightrail payment destination.
 
 + Request (application/json)
 
@@ -1002,7 +1002,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"81808811-f3d3-414d-b","source":{"rail":"lightrail","valueId":"7a283c03-f8e1-4407-a"},"destination":{"rail":"lightrail","valueId":"a39d02b4-d489-4d5e-9"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"6c096439-cdda-4bb4-b","source":{"rail":"lightrail","valueId":"3e9a9af9-fb60-4093-8"},"destination":{"rail":"lightrail","valueId":"020e522f-ed6f-41cd-9"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 201 (application/json)
 
@@ -1019,7 +1019,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"81808811-f3d3-414d-b","transactionType":"transfer","currency":"USD","createdDate":"2018-07-25T15:50:53.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"7a283c03-f8e1-4407-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"a39d02b4-d489-4d5e-9","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"6c096439-cdda-4bb4-b","transactionType":"transfer","currency":"USD","createdDate":"2018-07-25T16:11:18.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"3e9a9af9-fb60-4093-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"020e522f-ed6f-41cd-9","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 409 (application/json)
 
@@ -1049,7 +1049,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"bf44be20-4d66-4c8c-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T15:50:46.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"4d0da706-e2d0-4a59-8","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T16:11:13.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"779ef54c-0264-4e39-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 ### List Transactions [GET /transactions{?limit}{?transactionType}{?createdDate}{?maxCreatedDate}]
 
@@ -1447,7 +1447,6 @@ A Currency is a unit of money in Lightrail.  It can be a standard currency such 
 + id (string) - `internal`: the ID of the internal value.
 + balance (number) - `internal`: the amount of internal value stored.
 + beforeLightrail (boolean) - `internal`: if true this value is applied before Lightrail Values, otherwise it will be applied after.
-
 
 ## TransactionStep (object)
 A step taken as part of the transaction.

--- a/apiary.apib
+++ b/apiary.apib
@@ -130,14 +130,14 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"f9a0b596-198a-4a37-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
+            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"f9a0b596-198a-4a37-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T00:01:33.000Z","updatedDate":"2018-07-25T00:01:33.000Z"}
+            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T15:50:44.000Z","updatedDate":"2018-07-25T15:50:44.000Z"}
 ### Get a Contact [GET /contacts/{id}]
 
 + Parameter
@@ -153,7 +153,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"f9a0b596-198a-4a37-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T00:01:33.000Z","updatedDate":"2018-07-25T00:01:33.000Z"}
+            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T15:50:44.000Z","updatedDate":"2018-07-25T15:50:44.000Z"}
 
 ### List Contacts [GET /contacts{?limit}{?id}{?tags}{?firstName}{?lastName}{?email}]
         
@@ -212,7 +212,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"f9a0b596-198a-4a37-9","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-25T00:01:33.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+            {"id":"9fa9f457-0cb7-4f3b-9","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-25T15:50:44.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
 ### Delete a Contact [DELETE /contacts/{id}]
 
 + Parameter
@@ -280,7 +280,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            [{"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":"f9a0b596-198a-4a37-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}]
+            [{"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}]
 ### Attach a Contact to a Value [POST /contacts/{id}/values/attach]
 
 + Parameter
@@ -297,7 +297,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"valueId":"bc4377ca-a0a2-4511-b"}
+            {"valueId":"47c394da-66d3-4fe9-9"}
     
 + Response 200 (application/json)
     
@@ -309,7 +309,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":"f9a0b596-198a-4a37-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
 
 + Response 409 (application/json)
     
@@ -362,14 +362,14 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
         
     + Body
     
-            {"id":"bc4377ca-a0a2-4511-b","programId":"aa2552c8-1220-47d4-a","balance":500}
+            {"id":"47c394da-66d3-4fe9-9","programId":"794b8a78-0595-4130-a","balance":500}
     
 + Response 201 (application/json)
     + Attributes (Value)
 
     + Body
     
-            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
 ### Get a Value [GET /values/{id}{?showCode}]
 
 + Parameter
@@ -386,7 +386,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
 
 ### List Values [GET /values{?limit}{?showCode}{?programId}{?currency}{?contactId}{?balance}{?uses}{?discount}{?active}{?frozen}{?canceled}{?preTax}{?startDate}{?endDate}{?createdDate}{?updatedDate}{?tags}]
         
@@ -504,7 +504,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
     
-            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":"f9a0b596-198a-4a37-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+            {"id":"47c394da-66d3-4fe9-9","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:46.000Z"}
 ### Delete a Value [DELETE /values/{id}]
 
 + Parameter
@@ -561,7 +561,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"e9d90857-60bc-40b5-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":null,"code":"\u2026HDSX","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:38.000Z","updatedDate":"2018-07-25T00:01:38.000Z"}
+            {"id":"0f36f7c4-8c25-4840-b","currency":"USD","balance":500,"uses":null,"programId":"794b8a78-0595-4130-a","contactId":null,"code":"\u2026ZCFJ","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:52.000Z","updatedDate":"2018-07-25T15:50:52.000Z"}
 
 ## Programs [/programs]
 
@@ -596,14 +596,14 @@ Programs are most commonly used to define and organize promotion campaigns. For 
         
     + Body
 
-            {"id":"aa2552c8-1220-47d4-a","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
+            {"id":"794b8a78-0595-4130-a","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"aa2552c8-1220-47d4-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+            {"id":"794b8a78-0595-4130-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
 ### Get a Program [GET /programs/promotions/{id}]
 
 + Parameter
@@ -619,7 +619,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-                {"id":"aa2552c8-1220-47d4-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+                {"id":"794b8a78-0595-4130-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
 
 ### List Programs [GET /programs{?limit}{?id}{?name}{?preTax}{?currency}{?tags}{?startDate}{?endDate}{?createdDate}{?updatedDate}]
         
@@ -687,7 +687,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
             
-            {"id":"aa2552c8-1220-47d4-a","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
+            {"id":"794b8a78-0595-4130-a","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T15:50:45.000Z","updatedDate":"2018-07-25T15:50:45.000Z"}
 ### Delete a Program [DELETE /programs/{id}]
 
 + Parameter
@@ -852,7 +852,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
         
     + Body 
     
-            {"id":"b358b5b9-0125-49bf-8","sources":[{"rail":"lightrail","contactId":"f9a0b596-198a-4a37-9"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
+            {"id":"10ab73e9-0d54-4450-8","sources":[{"rail":"lightrail","contactId":"9fa9f457-0cb7-4f3b-9"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
     
 + Response 201 (application/json)
 
@@ -860,7 +860,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
     + Body
     
-            {"id":"b358b5b9-0125-49bf-8","transactionType":"checkout","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"6c94ffb7-78ad-4450-a","contactId":"f9a0b596-198a-4a37-9","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"0fda11c3-fad9-49da-9","contactId":"f9a0b596-198a-4a37-9","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1CraRhCM9MOvFvZK34yB37na","charge":{"id":"ch_1CraRhCM9MOvFvZK34yB37na","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1CraRhCM9MOvFvZKSp4PAyIu","captured":true,"created":1532476897,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"b358b5b9-0125-49bf-8","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"6c94ffb7-78ad-4450-a\"},{\"rail\":\"lightrail\",\"valueId\":\"0fda11c3-fad9-49da-9\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1CraRhCM9MOvFvZK34yB37na/refunds"},"review":null,"shipping":null,"source":{"id":"card_1CraRhCM9MOvFvZKRNFEhjq5","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"f9a0b596-198a-4a37-9"},{"rail":"stripe","source":"tok_visa","chargeId":"ch_1CraRhCM9MOvFvZK34yB37na"}],"metadata":null}
+            {"id":"10ab73e9-0d54-4450-8","transactionType":"checkout","currency":"USD","createdDate":"2018-07-25T15:50:47.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"d191f939-fc2a-4f1a-a","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"7065d163-e9ff-4091-8","contactId":"9fa9f457-0cb7-4f3b-9","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1CrpGJCM9MOvFvZKEAkzlix4","charge":{"id":"ch_1CrpGJCM9MOvFvZKEAkzlix4","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1CrpGJCM9MOvFvZKbaf9MC0j","captured":true,"created":1532533851,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"10ab73e9-0d54-4450-8","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"d191f939-fc2a-4f1a-a\"},{\"rail\":\"lightrail\",\"valueId\":\"7065d163-e9ff-4091-8\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1CrpGJCM9MOvFvZKEAkzlix4/refunds"},"review":null,"shipping":null,"source":{"id":"card_1CrpGJCM9MOvFvZKzXgLpMgi","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"9fa9f457-0cb7-4f3b-9"},{"rail":"stripe","source":"tok_visa","chargeId":"ch_1CrpGJCM9MOvFvZKEAkzlix4"}],"metadata":null}
 
 + Response 409 (application/json)
 
@@ -924,7 +924,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"9aae50dd-c190-4312-8","source":{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"bf44be20-4d66-4c8c-9","source":{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
     
 + Response 201 (application/json)
 
@@ -932,7 +932,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"9aae50dd-c190-4312-8","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"bf44be20-4d66-4c8c-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T15:50:46.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 + Response 409 (application/json)
 
@@ -969,7 +969,7 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
 
     + Body
 
-            {"id":"19f26e2c-806f-4295-8","destination":{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"dc64ecd3-5e03-4189-a","destination":{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
     
 + Response 201 (application/json)
 
@@ -977,7 +977,7 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
 
     + Body
 
-            {"id":"19f26e2c-806f-4295-8","transactionType":"credit","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"dc64ecd3-5e03-4189-a","transactionType":"credit","currency":"USD","createdDate":"2018-07-25T15:50:46.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
 
 ### Transfer [POST /transactions/transfer]
 
@@ -1002,7 +1002,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"07a04510-f920-4157-8","source":{"rail":"lightrail","valueId":"9cb304d4-3e3f-408c-8"},"destination":{"rail":"lightrail","valueId":"3fce3ac4-d5ff-4a41-8"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"81808811-f3d3-414d-b","source":{"rail":"lightrail","valueId":"7a283c03-f8e1-4407-a"},"destination":{"rail":"lightrail","valueId":"a39d02b4-d489-4d5e-9"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 201 (application/json)
 
@@ -1019,7 +1019,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"07a04510-f920-4157-8","transactionType":"transfer","currency":"USD","createdDate":"2018-07-25T00:01:39.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"9cb304d4-3e3f-408c-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"3fce3ac4-d5ff-4a41-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"81808811-f3d3-414d-b","transactionType":"transfer","currency":"USD","createdDate":"2018-07-25T15:50:53.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"7a283c03-f8e1-4407-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"a39d02b4-d489-4d5e-9","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 409 (application/json)
 
@@ -1049,7 +1049,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"9aae50dd-c190-4312-8","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"bf44be20-4d66-4c8c-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T15:50:46.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1f54373f-f67a-4639-9","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 ### List Transactions [GET /transactions{?limit}{?transactionType}{?createdDate}{?maxCreatedDate}]
 
@@ -1398,10 +1398,7 @@ A Currency is a unit of money in Lightrail.  It can be a standard currency such 
 + message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
 + messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
 
-## StripeRestError (object)
-+ statusCode (number) - the HTTP status code.
-+ message (string) - an English explanation of the error.  This is for display purposes only as the explanation may be formatted or change between system updates.
-+ messageCode (string) - A constant corresponding to the message.  This can be used to take action in response to the error.
+## StripeRestError (RestError)
 + stripeError (object) - When using the `stripe` rail: the full error response from Stripe in case of an error charging a credit card.
 
 ## Rule (object)
@@ -1433,32 +1430,24 @@ A Currency is a unit of money in Lightrail.  It can be a standard currency such 
 + sellerGross (number) - The amount payable to the seller before discounts.
 + sellerNet (number) - The amount payable to the seller after discounts.
 
-## TransactionParty (object)
-+ rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`, `internal`]. Must be used in combination with one of the following identifiers.
-+ code (string) - `lightrail`: the code of a Gift Card or Promotion.
-+ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
-+ valueId (string) - `lightrail`: a Value's ID.
-+ source (string) - `stripe`: a tokenized credit card for Stripe.  
-+ customer (string) - `stripe`: a Stripe customer ID (uses customer's default source).  
-+ maxAmount (number) - `stripe`: the maximum amount that can be charged to the given Stripe source.  
-+ id (string) - `internal`: the ID of the internal value.
-+ balance (number) - `internal`: the amount of internal value stored.
-+ beforeLightrail (boolean) - `internal`: if true this value is applied before Lightrail Values, otherwise it will be applied after.
-
 ## LightrailTransactionParty (object)
 + rail (string) - The payment rail: `lightrail`. Must be used in combination with one of the following identifiers.
 + code (string) - `lightrail`: the code of a Gift Card or Promotion.
 + contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
 + valueId (string) - `lightrail`: a Value's ID.
 
-## StripeOrLightrailTransactionParty (object)
+## StripeOrLightrailTransactionParty (LightrailTransactionParty)
 + rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`]. Must be used in combination with one of the following identifiers.
-+ code (string) - `lightrail`: the code of a Gift Card or Promotion.
-+ contactId (string) - `lightrail`: a Contact's ID.  This is shorthand for all Values that a Contact is associated with.
-+ valueId (string) - `lightrail`: a Value's ID.
 + source (string) - `stripe`: a tokenized credit card for Stripe.  
 + customer (string) - `stripe`: a Stripe customer ID (uses customer's default source).  
 + maxAmount (number) - `stripe`: the maximum amount that can be charged to the given Stripe source.  
+
+## TransactionParty (StripeOrLightrailTransactionParty)
++ rail (string) - The payment rail. Must belong to [`lightrail`, `stripe`, `internal`]. Must be used in combination with one of the following identifiers.
++ id (string) - `internal`: the ID of the internal value.
++ balance (number) - `internal`: the amount of internal value stored.
++ beforeLightrail (boolean) - `internal`: if true this value is applied before Lightrail Values, otherwise it will be applied after.
+
 
 ## TransactionStep (object)
 A step taken as part of the transaction.

--- a/apiary.apib
+++ b/apiary.apib
@@ -130,14 +130,14 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"221c75df-bd39-4a3a-8","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
+            {"id":"f9a0b596-198a-4a37-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"221c75df-bd39-4a3a-8","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
+            {"id":"f9a0b596-198a-4a37-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T00:01:33.000Z","updatedDate":"2018-07-25T00:01:33.000Z"}
 ### Get a Contact [GET /contacts/{id}]
 
 + Parameter
@@ -153,7 +153,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"221c75df-bd39-4a3a-8","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
+            {"id":"f9a0b596-198a-4a37-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-07-25T00:01:33.000Z","updatedDate":"2018-07-25T00:01:33.000Z"}
 
 ### List Contacts [GET /contacts{?limit}{?id}{?tags}{?firstName}{?lastName}{?email}]
         
@@ -212,7 +212,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"221c75df-bd39-4a3a-8","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
+            {"id":"f9a0b596-198a-4a37-9","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-07-25T00:01:33.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 ### Delete a Contact [DELETE /contacts/{id}]
 
 + Parameter
@@ -280,7 +280,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            [{"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":"221c75df-bd39-4a3a-8","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}]
+            [{"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":"f9a0b596-198a-4a37-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}]
 ### Attach a Contact to a Value [POST /contacts/{id}/values/attach]
 
 + Parameter
@@ -297,7 +297,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"valueId":"8a3fd91b-c715-4927-8"}
+            {"valueId":"bc4377ca-a0a2-4511-b"}
     
 + Response 200 (application/json)
     
@@ -309,7 +309,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":"221c75df-bd39-4a3a-8","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
+            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":"f9a0b596-198a-4a37-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 
 + Response 409 (application/json)
     
@@ -362,14 +362,14 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
         
     + Body
     
-            {"id":"8a3fd91b-c715-4927-8","programId":"28c238ef-d3cf-473e-b","balance":500}
+            {"id":"bc4377ca-a0a2-4511-b","programId":"aa2552c8-1220-47d4-a","balance":500}
     
 + Response 201 (application/json)
     + Attributes (Value)
 
     + Body
     
-            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
+            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 ### Get a Value [GET /values/{id}{?showCode}]
 
 + Parameter
@@ -386,7 +386,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
+            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","code":null,"isGenericCode":null,"contactId":null,"pretax":true,"active":true,"frozen":false,"redemptionRule":null,"valueRule":null,"discount":true,"discountSellerLiability":null,"startDate":null,"endDate":null,"metadata":null,"canceled":false,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 
 ### List Values [GET /values{?limit}{?showCode}{?programId}{?currency}{?contactId}{?balance}{?uses}{?discount}{?active}{?frozen}{?canceled}{?preTax}{?startDate}{?endDate}{?createdDate}{?updatedDate}{?tags}]
         
@@ -504,7 +504,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
     
-            {"id":"8a3fd91b-c715-4927-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":"221c75df-bd39-4a3a-8","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:31.000Z","updatedDate":"2018-07-24T23:50:31.000Z"}
+            {"id":"bc4377ca-a0a2-4511-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":"f9a0b596-198a-4a37-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 ### Delete a Value [DELETE /values/{id}]
 
 + Parameter
@@ -561,7 +561,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"a1e10b10-dee5-43d9-8","currency":"USD","balance":500,"uses":null,"programId":"28c238ef-d3cf-473e-b","contactId":null,"code":"\u2026REAN","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:35.000Z","updatedDate":"2018-07-24T23:50:35.000Z"}
+            {"id":"e9d90857-60bc-40b5-b","currency":"USD","balance":500,"uses":null,"programId":"aa2552c8-1220-47d4-a","contactId":null,"code":"\u2026HDSX","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:38.000Z","updatedDate":"2018-07-25T00:01:38.000Z"}
 
 ## Programs [/programs]
 
@@ -596,14 +596,14 @@ Programs are most commonly used to define and organize promotion campaigns. For 
         
     + Body
 
-            {"id":"28c238ef-d3cf-473e-b","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
+            {"id":"aa2552c8-1220-47d4-a","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"28c238ef-d3cf-473e-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
+            {"id":"aa2552c8-1220-47d4-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 ### Get a Program [GET /programs/promotions/{id}]
 
 + Parameter
@@ -619,7 +619,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-                {"id":"28c238ef-d3cf-473e-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
+                {"id":"aa2552c8-1220-47d4-a","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 
 ### List Programs [GET /programs{?limit}{?id}{?name}{?preTax}{?currency}{?tags}{?startDate}{?endDate}{?createdDate}{?updatedDate}]
         
@@ -687,7 +687,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
             
-            {"id":"28c238ef-d3cf-473e-b","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-24T23:50:30.000Z","updatedDate":"2018-07-24T23:50:30.000Z"}
+            {"id":"aa2552c8-1220-47d4-a","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-07-25T00:01:34.000Z","updatedDate":"2018-07-25T00:01:34.000Z"}
 ### Delete a Program [DELETE /programs/{id}]
 
 + Parameter
@@ -852,7 +852,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
         
     + Body 
     
-            {"id":"1976c09c-07d5-4180-b","sources":[{"rail":"lightrail","contactId":"221c75df-bd39-4a3a-8"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
+            {"id":"b358b5b9-0125-49bf-8","sources":[{"rail":"lightrail","contactId":"f9a0b596-198a-4a37-9"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
     
 + Response 201 (application/json)
 
@@ -860,7 +860,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
     + Body
     
-            {"id":"1976c09c-07d5-4180-b","transactionType":"checkout","currency":"USD","createdDate":"2018-07-24T23:50:32.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"3ae128ae-4062-4aa0-8","contactId":"221c75df-bd39-4a3a-8","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"5b9e2163-48d5-476a-8","contactId":"221c75df-bd39-4a3a-8","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1CraH0CM9MOvFvZKuN73dOwG","charge":{"id":"ch_1CraH0CM9MOvFvZKuN73dOwG","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1CraH0CM9MOvFvZKe4QrKVSN","captured":true,"created":1532476234,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"1976c09c-07d5-4180-b","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"3ae128ae-4062-4aa0-8\"},{\"rail\":\"lightrail\",\"valueId\":\"5b9e2163-48d5-476a-8\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1CraH0CM9MOvFvZKuN73dOwG/refunds"},"review":null,"shipping":null,"source":{"id":"card_1CraH0CM9MOvFvZKGynLyHig","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"221c75df-bd39-4a3a-8"},{"rail":"stripe","source":"tok_visa","chargeId":"ch_1CraH0CM9MOvFvZKuN73dOwG"}],"metadata":null}
+            {"id":"b358b5b9-0125-49bf-8","transactionType":"checkout","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"6c94ffb7-78ad-4450-a","contactId":"f9a0b596-198a-4a37-9","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"0fda11c3-fad9-49da-9","contactId":"f9a0b596-198a-4a37-9","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1CraRhCM9MOvFvZK34yB37na","charge":{"id":"ch_1CraRhCM9MOvFvZK34yB37na","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1CraRhCM9MOvFvZKSp4PAyIu","captured":true,"created":1532476897,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"b358b5b9-0125-49bf-8","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"6c94ffb7-78ad-4450-a\"},{\"rail\":\"lightrail\",\"valueId\":\"0fda11c3-fad9-49da-9\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1CraRhCM9MOvFvZK34yB37na/refunds"},"review":null,"shipping":null,"source":{"id":"card_1CraRhCM9MOvFvZKRNFEhjq5","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"f9a0b596-198a-4a37-9"},{"rail":"stripe","source":"tok_visa","chargeId":"ch_1CraRhCM9MOvFvZK34yB37na"}],"metadata":null}
 
 + Response 409 (application/json)
 
@@ -913,7 +913,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
         
     + Attributes
         + id (string, required) - ID for the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
-        + source (TransactionParty, required) - The rail to debit.  Only `lightrail` rails that refer to a specific Value are supported.
+        + source (LightrailTransactionParty, required) - The rail to debit.  Only `lightrail` rails that refer to a specific Value are supported.
         + amount (number, required) - The amount to debit, > 0.
         + uses (number, optional) - The number of uses to remove.  Defaults to 0.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
@@ -924,7 +924,7 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"1f6042c7-e4c9-4096-9","source":{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"9aae50dd-c190-4312-8","source":{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
     
 + Response 201 (application/json)
 
@@ -932,13 +932,13 @@ Debit (remove from) a payment source.  Currently only the `lightrail` rail is su
 
     + Body
 
-            {"id":"1f6042c7-e4c9-4096-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-24T23:50:31.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"9aae50dd-c190-4312-8","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 + Response 409 (application/json)
 
     You cannot debit a Value by more balance than is available (if `allowRemainder` is not `true`).
 
-    + Attributes (Transaction)
+    + Attributes (RestError)
 
     + Body
 
@@ -959,7 +959,7 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
         
     + Attributes
         + id (string, required) - ID for the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
-        + destination (TransactionParty, required) - The rail to credit.  Only `lightrail` rails that refer to a specific Value are supported.
+        + destination (LightrailTransactionParty, required) - The rail to credit.  Only `lightrail` rails that refer to a specific Value are supported.
         + amount (number, required) - The amount to credit, > 0.
         + uses (number, optional) - The number of uses to add.  Defaults to 0.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
@@ -969,15 +969,15 @@ Credit (add to) a payment destination.  Currently only the `lightrail` rail is s
 
     + Body
 
-            {"id":"d15979ec-dbc9-4dda-b","destination":{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"19f26e2c-806f-4295-8","destination":{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
     
 + Response 201 (application/json)
 
-    + Attributes (Transaction)
+    + Attributes (RestError)
 
     + Body
 
-            {"id":"d15979ec-dbc9-4dda-b","transactionType":"credit","currency":"USD","createdDate":"2018-07-24T23:50:31.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"19f26e2c-806f-4295-8","transactionType":"credit","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
 
 ### Transfer [POST /transactions/transfer]
 
@@ -1002,7 +1002,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"9f3c1bfb-c1c7-480d-8","source":{"rail":"lightrail","valueId":"0f15c587-8450-41d7-a"},"destination":{"rail":"lightrail","valueId":"f1c8e671-af44-4b43-a"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"07a04510-f920-4157-8","source":{"rail":"lightrail","valueId":"9cb304d4-3e3f-408c-8"},"destination":{"rail":"lightrail","valueId":"3fce3ac4-d5ff-4a41-8"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 201 (application/json)
 
@@ -1019,7 +1019,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"9f3c1bfb-c1c7-480d-8","transactionType":"transfer","currency":"USD","createdDate":"2018-07-24T23:50:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"0f15c587-8450-41d7-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"f1c8e671-af44-4b43-a","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"07a04510-f920-4157-8","transactionType":"transfer","currency":"USD","createdDate":"2018-07-25T00:01:39.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"9cb304d4-3e3f-408c-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"3fce3ac4-d5ff-4a41-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 409 (application/json)
 
@@ -1049,7 +1049,7 @@ Transfer value between a payment source and a payment destination.  Currently th
 
     + Body
 
-            {"id":"1f6042c7-e4c9-4096-9","transactionType":"debit","currency":"USD","createdDate":"2018-07-24T23:50:31.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"d9cf5459-4370-4774-a","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"9aae50dd-c190-4312-8","transactionType":"debit","currency":"USD","createdDate":"2018-07-25T00:01:35.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"5e1e9ef8-1121-4b70-8","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 ### List Transactions [GET /transactions{?limit}{?transactionType}{?createdDate}{?maxCreatedDate}]
 


### PR DESCRIPTION
A couple things that aren't strictly related to Stripe updates: 
- Clarified the source/destination details for the different types of Transactions: `debit` & `credit` currently only support the `lightrail` rail so details for `stripe` & `internal` don't need to be in there right now. Similarly, `transfer` only supports `lightrail` & `stripe`. 
- A few endpoint examples showed the error response attributes as being the same as the success response attributes, these have been updated. 