### PR TITLE
Live alpha update

### DIFF
--- a/apiary-sources/api-sections/programs.md
+++ b/apiary-sources/api-sections/programs.md
@@ -1,6 +1,6 @@
 ## Programs [/programs]
 
-Programs organize [Values](#reference/0/values) and Values can be [issued](#reference/0/issuing-value) from Programs.  Programs are typically created through the web app.
+Programs organize [Values](#reference/0/values) and Values can be [issued](#reference/0/programs/create-issuance) from Programs.  Programs are typically created through the web app.
 
 Programs are most commonly used to define and organize promotion campaigns. For example, the Value issued for a new user promotion that gives them a 5% discount on their first purchase should behave differently from the Value for a "TEN-DOLLAR-TUESDAYS" promotion. These different promotions will also need to be tracked and analyzed separately, all of which can happen in the web app.
 

--- a/apiary-sources/api-sections/values.md
+++ b/apiary-sources/api-sections/values.md
@@ -1,6 +1,6 @@
 ## Values [/values]
 
-A Value (naturally) represents value in the Lightrail system.  This includes a gift card, a promotion, a coupon, store credit, etc.  Values can be created one at a time but are most often [issued](#reference/0/issuing-value/issue-values) from a [Program](#reference/0/programs).  Issuing Value from a Program makes it part of that Program which keeps different ways of using Value organized.
+A Value (naturally) represents value in the Lightrail system.  This includes a gift card, a promotion, a coupon, store credit, etc.  Values can be created one at a time but are most often [issued](#reference/0/programs/create-issuance) from a [Program](#reference/0/programs).  Issuing Value from a Program makes it part of that Program which keeps different ways of using Value organized.
  
 Most Values will be accessed by a code, or attached to a [Contact](#reference/0/contacts).  All Values attached to a Contact can be used in a [checkout Transaction](#reference/0/transactions/checkout) by only specifying the Contact.
 

--- a/apiary-sources/data-structures/Transaction.md
+++ b/apiary-sources/data-structures/Transaction.md
@@ -14,7 +14,7 @@
 + discount (number) - The amount of discounts applies.
 + marketplace (TransactionTotalsMarketplace) - Marketplace totals calculated if any marketplace behaviour has been configured (by setting the LineItem `marketplaceRate`).
 + payable (number) - The amount payable.
-+ remainder (number) - The remainder of balance that could not be debited or charged.
++ remainder (number) - {{transaction.remainderResponse}}
 + subtotal (number) - The sum of all products, services and fees before tax or discounts.
 + tax (number) - The amount of tax to be collected.
 

--- a/apiary-sources/endpoints/programs-create.md
+++ b/apiary-sources/endpoints/programs-create.md
@@ -28,7 +28,7 @@
             {REQUEST_REPLACEMENT:createProgram1.body}
     
 + Response 201 (application/json)
-    + Attributes (Contact)
+    + Attributes (Program)
 
     + Body
             

--- a/apiary-sources/endpoints/transactions-transfer.md
+++ b/apiary-sources/endpoints/transactions-transfer.md
@@ -30,7 +30,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
         + transactionType (string, required) - `transfer`
         + currency (string, required) - {{currency.code}}
         + steps (array[TransactionStep], required) - {{transaction.steps}}
-        + remainder (number, required) - {{transaction.remainder}}
+        + remainder (number, required) - {{transaction.remainderResponse}}
         + simulated (boolean, optional) - {{transaction.simulated}}
         + createdDate (string, required) - {{transaction.createdDate}}
         + pending (boolean, optional) - {{transaction.pending}}

--- a/apiary-sources/endpoints/values-get.md
+++ b/apiary-sources/endpoints/values-get.md
@@ -16,6 +16,24 @@
 
             {REQUEST_REPLACEMENT:createValue1.response.body}
 
+### Get a Value by Code [GET /values?code={code}{?showCode}]
+
++ Parameter
+    + code (string) - the code (secret or generic) of the Value to get.
+    + showCode (boolean, optional) - {{value.showCode}}
+
++ Request (application/json)
+    + Headers
+
+            {{header.authorization}}
+
++ Response 200 (application/json)
+    + Attributes (Value)
+
+    + Body
+
+            {REQUEST_REPLACEMENT:createValue1.response.body}
+
 ### List Values [GET /values{?limit}{?showCode}{?programId}{?currency}{?contactId}{?balance}{?uses}{?discount}{?active}{?frozen}{?canceled}{?preTax}{?startDate}{?endDate}{?createdDate}{?updatedDate}{?tags}]
         
 + Parameter

--- a/apiary-sources/metadata.yaml
+++ b/apiary-sources/metadata.yaml
@@ -88,7 +88,8 @@ program:
     startDate: "Override the Program's configured startDate."
     endDate: "Override the Program's configured endDate."
 transaction:
-  allowRemainder: "If true the transaction will go through without all balance being debited, and the remainder indicated."
+  allowRemainder: "If true the transaction will go through using whatever amount is available: this might not cover the full amount of the transaction. The remainder (i.e. amount still owing) will be indicated."
+  remainderResponse: "The amount still owing, if a remainder is allowed by setting `allowRemainder: true`."
   createdDate: "Date when the Transaction was created."
   destination: "Only supported rail is `\"lightrail\"` and must it refer to a single Value."
   id: "ID for the Transaction."

--- a/apiary.apib
+++ b/apiary.apib
@@ -130,14 +130,14 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"4cbda15e-3d85-40b0-b","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
+            {"id":"caba6d00-b702-4d5b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"4cbda15e-3d85-40b0-b","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"caba6d00-b702-4d5b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-08-07T19:12:03.000Z","updatedDate":"2018-08-07T19:12:03.000Z"}
 ### Get a Contact [GET /contacts/{id}]
 
 + Parameter
@@ -153,7 +153,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"4cbda15e-3d85-40b0-b","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"caba6d00-b702-4d5b-9","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2018-08-07T19:12:03.000Z","updatedDate":"2018-08-07T19:12:03.000Z"}
 
 ### List Contacts [GET /contacts{?limit}{?id}{?tags}{?firstName}{?lastName}{?email}]
         
@@ -212,7 +212,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"4cbda15e-3d85-40b0-b","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"caba6d00-b702-4d5b-9","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2018-08-07T19:12:03.000Z","updatedDate":"2018-08-07T19:12:03.000Z"}
 ### Delete a Contact [DELETE /contacts/{id}]
 
 + Parameter
@@ -280,7 +280,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            [{"id":"1efd8608-d636-4064-b","currency":"USD","balance":500,"uses":null,"programId":"fde0d56e-aff7-4d38-b","issuanceId":null,"contactId":"4cbda15e-3d85-40b0-b","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}]
+            [{"id":"bd4b64c5-8edc-43fa-a","currency":"USD","balance":500,"uses":null,"programId":"ebd78277-0251-42e8-9","issuanceId":null,"contactId":"caba6d00-b702-4d5b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:04.000Z","updatedDate":"2018-08-07T19:12:04.000Z"}]
 ### Attach a Contact to a Value [POST /contacts/{id}/values/attach]
 
 + Parameter
@@ -297,7 +297,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"valueId":"1efd8608-d636-4064-b"}
+            {"valueId":"bd4b64c5-8edc-43fa-a"}
     
 + Response 200 (application/json)
     
@@ -309,7 +309,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"1efd8608-d636-4064-b","currency":"USD","balance":500,"uses":null,"programId":"fde0d56e-aff7-4d38-b","issuanceId":null,"contactId":"4cbda15e-3d85-40b0-b","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"bd4b64c5-8edc-43fa-a","currency":"USD","balance":500,"uses":null,"programId":"ebd78277-0251-42e8-9","issuanceId":null,"contactId":"caba6d00-b702-4d5b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:04.000Z","updatedDate":"2018-08-07T19:12:04.000Z"}
 
 + Response 409 (application/json)
     
@@ -327,7 +327,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
 ## Values [/values]
 
-A Value (naturally) represents value in the Lightrail system.  This includes a gift card, a promotion, a coupon, store credit, etc.  Values can be created one at a time but are most often [issued](#reference/0/issuing-value/issue-values) from a [Program](#reference/0/programs).  Issuing Value from a Program makes it part of that Program which keeps different ways of using Value organized.
+A Value (naturally) represents value in the Lightrail system.  This includes a gift card, a promotion, a coupon, store credit, etc.  Values can be created one at a time but are most often [issued](#reference/0/programs/create-issuance) from a [Program](#reference/0/programs).  Issuing Value from a Program makes it part of that Program which keeps different ways of using Value organized.
  
 Most Values will be accessed by a code, or attached to a [Contact](#reference/0/contacts).  All Values attached to a Contact can be used in a [checkout Transaction](#reference/0/transactions/checkout) by only specifying the Contact.
 
@@ -365,14 +365,14 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
         
     + Body
     
-            {"id":"1efd8608-d636-4064-b","programId":"fde0d56e-aff7-4d38-b","balance":500}
+            {"id":"bd4b64c5-8edc-43fa-a","programId":"ebd78277-0251-42e8-9","balance":500}
     
 + Response 201 (application/json)
     + Attributes (Value)
 
     + Body
     
-            {"id":"1efd8608-d636-4064-b","currency":"USD","balance":500,"uses":null,"programId":"fde0d56e-aff7-4d38-b","issuanceId":null,"contactId":null,"code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"bd4b64c5-8edc-43fa-a","currency":"USD","balance":500,"uses":null,"programId":"ebd78277-0251-42e8-9","issuanceId":null,"contactId":null,"code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:04.000Z","updatedDate":"2018-08-07T19:12:04.000Z"}
 ### Get a Value [GET /values/{id}{?showCode}]
 
 + Parameter
@@ -389,7 +389,25 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"1efd8608-d636-4064-b","currency":"USD","balance":500,"uses":null,"programId":"fde0d56e-aff7-4d38-b","issuanceId":null,"contactId":null,"code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"bd4b64c5-8edc-43fa-a","currency":"USD","balance":500,"uses":null,"programId":"ebd78277-0251-42e8-9","issuanceId":null,"contactId":null,"code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:04.000Z","updatedDate":"2018-08-07T19:12:04.000Z"}
+
+### Get a Value by Code [GET /values?code={code}{?showCode}]
+
++ Parameter
+    + code (string) - the code (secret or generic) of the Value to get.
+    + showCode (boolean, optional) - Show the full code for the Value.
+
++ Request (application/json)
+    + Headers
+
+            Authorization: Bearer <API_KEY>
+
++ Response 200 (application/json)
+    + Attributes (Value)
+
+    + Body
+
+            {"id":"bd4b64c5-8edc-43fa-a","currency":"USD","balance":500,"uses":null,"programId":"ebd78277-0251-42e8-9","issuanceId":null,"contactId":null,"code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:04.000Z","updatedDate":"2018-08-07T19:12:04.000Z"}
 
 ### List Values [GET /values{?limit}{?showCode}{?programId}{?currency}{?contactId}{?balance}{?uses}{?discount}{?active}{?frozen}{?canceled}{?preTax}{?startDate}{?endDate}{?createdDate}{?updatedDate}{?tags}]
         
@@ -507,7 +525,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
     
-            {"id":"1efd8608-d636-4064-b","currency":"USD","balance":500,"uses":null,"programId":"fde0d56e-aff7-4d38-b","issuanceId":null,"contactId":"4cbda15e-3d85-40b0-b","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:25.000Z"}
+            {"id":"bd4b64c5-8edc-43fa-a","currency":"USD","balance":500,"uses":null,"programId":"ebd78277-0251-42e8-9","issuanceId":null,"contactId":"caba6d00-b702-4d5b-9","code":null,"isGenericCode":null,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:04.000Z","updatedDate":"2018-08-07T19:12:04.000Z"}
 ### Delete a Value [DELETE /values/{id}]
 
 + Parameter
@@ -564,11 +582,11 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"9bc578b9-a78e-4f44-9","currency":"USD","balance":500,"uses":null,"programId":"fde0d56e-aff7-4d38-b","issuanceId":null,"contactId":null,"code":"\u2026YADU","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:28.000Z","updatedDate":"2018-08-02T21:12:28.000Z"}
+            {"id":"211b9094-3332-4641-8","currency":"USD","balance":500,"uses":null,"programId":"ebd78277-0251-42e8-9","issuanceId":null,"contactId":null,"code":"\u2026H6CP","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:08.000Z","updatedDate":"2018-08-07T19:12:08.000Z"}
 
 ## Programs [/programs]
 
-Programs organize [Values](#reference/0/values) and Values can be [issued](#reference/0/issuing-value) from Programs.  Programs are typically created through the web app.
+Programs organize [Values](#reference/0/values) and Values can be [issued](#reference/0/programs/create-issuance) from Programs.  Programs are typically created through the web app.
 
 Programs are most commonly used to define and organize promotion campaigns. For example, the Value issued for a new user promotion that gives them a 5% discount on their first purchase should behave differently from the Value for a "TEN-DOLLAR-TUESDAYS" promotion. These different promotions will also need to be tracked and analyzed separately, all of which can happen in the web app.
 
@@ -599,14 +617,14 @@ Programs are most commonly used to define and organize promotion campaigns. For 
         
     + Body
 
-            {"id":"fde0d56e-aff7-4d38-b","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
+            {"id":"ebd78277-0251-42e8-9","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
     
 + Response 201 (application/json)
-    + Attributes (Contact)
+    + Attributes (Program)
 
     + Body
             
-            {"id":"fde0d56e-aff7-4d38-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"ebd78277-0251-42e8-9","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:03.000Z","updatedDate":"2018-08-07T19:12:03.000Z"}
 ### Get a Program [GET /programs/promotions/{id}]
 
 + Parameter
@@ -622,7 +640,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-                {"id":"fde0d56e-aff7-4d38-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+                {"id":"ebd78277-0251-42e8-9","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"redemptionRule":null,"valueRule":null,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:03.000Z","updatedDate":"2018-08-07T19:12:03.000Z"}
 
 ### List Programs [GET /programs{?limit}{?id}{?name}{?preTax}{?currency}{?tags}{?startDate}{?endDate}{?createdDate}{?updatedDate}]
         
@@ -690,7 +708,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
             
-            {"id":"fde0d56e-aff7-4d38-b","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:24.000Z","updatedDate":"2018-08-02T21:12:24.000Z"}
+            {"id":"ebd78277-0251-42e8-9","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUses":null,"redemptionRule":null,"valueRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:03.000Z","updatedDate":"2018-08-07T19:12:03.000Z"}
 ### Delete a Program [DELETE /programs/{id}]
 
 + Parameter
@@ -748,14 +766,14 @@ Programs are most commonly used to define and organize promotion campaigns. For 
         
     + Body
     
-            {"id":"45e42064-e567-4f77-9","count":10,"generateCode":{},"balance":500}
+            {"id":"36b44e36-9771-45ac-9","count":10,"generateCode":{},"balance":500}
     
 + Response 201 (application/json)
     + Attributes (Issuance)
 
     + Body
     
-            {"id":"45e42064-e567-4f77-9","programId":"fde0d56e-aff7-4d38-b","count":10,"balance":500,"redemptionRule":null,"valueRule":null,"uses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:29.000Z","updatedDate":"2018-08-02T21:12:29.000Z"}
+            {"id":"36b44e36-9771-45ac-9","programId":"ebd78277-0251-42e8-9","count":10,"balance":500,"redemptionRule":null,"valueRule":null,"uses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:09.000Z","updatedDate":"2018-08-07T19:12:09.000Z"}
 ### Get an Issuance [GET /programs/{programId}/issuances/{id}]
 
 + Parameter
@@ -772,7 +790,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-            {"id":"45e42064-e567-4f77-9","programId":"fde0d56e-aff7-4d38-b","count":10,"balance":500,"redemptionRule":null,"valueRule":null,"uses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-02T21:12:29.000Z","updatedDate":"2018-08-02T21:12:29.000Z"}
+            {"id":"36b44e36-9771-45ac-9","programId":"ebd78277-0251-42e8-9","count":10,"balance":500,"redemptionRule":null,"valueRule":null,"uses":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2018-08-07T19:12:09.000Z","updatedDate":"2018-08-07T19:12:09.000Z"}
 
 ### List Issuances [GET /programs/{id}/issuances]
 
@@ -825,13 +843,13 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
         + lineItems (array[LineItem])
         + sources (array[TransactionParty])
         + simulate (boolean, optional) - If true the transaction is simulated and no changes take place. If the transaction is repeated with simulate=false it is not guaranteed to behave the same way as the underlying Values can change.
-        + allowRemainder (boolean, optional) - If true the transaction will go through without all balance being debited, and the remainder indicated.
+        + allowRemainder (boolean, optional) - If true the transaction will go through using whatever amount is available: this might not cover the full amount of the transaction. The remainder (i.e. amount still owing) will be indicated.
         + pending (boolean, optional) - If true the transaction is created as pending and does not complete until captured. The transaction will be automatically voided if not captured.
         + metadata (object, optional) - Any additional data you want to store for the item. All metadata will also be saved on any Stripe charge(s).
         
     + Body 
     
-            {"id":"0ab4b6b4-d11f-4433-b","sources":[{"rail":"lightrail","contactId":"4cbda15e-3d85-40b0-b"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
+            {"id":"595ef143-4424-41a6-9","sources":[{"rail":"lightrail","contactId":"caba6d00-b702-4d5b-9"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
     
 + Response 201 (application/json)
 
@@ -839,7 +857,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
     + Body
     
-            {"id":"0ab4b6b4-d11f-4433-b","transactionType":"checkout","currency":"USD","createdDate":"2018-08-02T21:12:26.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"e3228040-c062-4e59-9","contactId":"4cbda15e-3d85-40b0-b","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"50cb0bd3-3e85-4669-9","contactId":"4cbda15e-3d85-40b0-b","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1Cuo5vCM9MOvFvZKlELcPwdM","charge":{"id":"ch_1Cuo5vCM9MOvFvZKlELcPwdM","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1Cuo5vCM9MOvFvZKXAN7I1dL","captured":true,"created":1533244347,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"0ab4b6b4-d11f-4433-b","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"e3228040-c062-4e59-9\"},{\"rail\":\"lightrail\",\"valueId\":\"50cb0bd3-3e85-4669-9\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1Cuo5vCM9MOvFvZKlELcPwdM/refunds"},"review":null,"shipping":null,"source":{"id":"card_1Cuo5vCM9MOvFvZKitpXIYlO","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":8,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"4cbda15e-3d85-40b0-b"},{"rail":"stripe","source":"tok_visa"}],"metadata":null}
+            {"id":"595ef143-4424-41a6-9","transactionType":"checkout","currency":"USD","createdDate":"2018-08-07T19:12:05.000Z","totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"a1ca4075-ca89-419d-8","contactId":"caba6d00-b702-4d5b-9","code":null,"balanceBefore":0,"balanceAfter":0,"balanceChange":-200},{"rail":"lightrail","valueId":"12c10023-d8b0-48b5-8","contactId":"caba6d00-b702-4d5b-9","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000},{"rail":"stripe","chargeId":"ch_1CwabDCM9MOvFvZK5uic2pA0","charge":{"id":"ch_1CwabDCM9MOvFvZK5uic2pA0","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"balance_transaction":"txn_1CwabDCM9MOvFvZKb563zPjL","captured":true,"created":1533669127,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"595ef143-4424-41a6-9","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"a1ca4075-ca89-419d-8\"},{\"rail\":\"lightrail\",\"valueId\":\"12c10023-d8b0-48b5-8\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","seller_message":"Payment complete.","type":"authorized"},"paid":true,"receipt_email":null,"receipt_number":null,"refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1CwabDCM9MOvFvZK5uic2pA0/refunds"},"review":null,"shipping":null,"source":{"id":"card_1CwabDCM9MOvFvZKzDJGwczM","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":8,"exp_year":2019,"fingerprint":"of2hPOxbCXt9w9BD","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"caba6d00-b702-4d5b-9"},{"rail":"stripe","source":"tok_visa"}],"metadata":null}
 
 + Response 409 (application/json)
 
@@ -897,13 +915,13 @@ Debit (remove an amount from) a Lightrail payment source.
         + uses (number, optional) - The number of uses to remove.  Defaults to 0.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + simulate (boolean, optional) - If true the transaction is simulated and no changes take place. If the transaction is repeated with simulate=false it is not guaranteed to behave the same way as the underlying Values can change.
-        + allowRemainder (boolean, optional) - If true the transaction will go through without all balance being debited, and the remainder indicated.
+        + allowRemainder (boolean, optional) - If true the transaction will go through using whatever amount is available: this might not cover the full amount of the transaction. The remainder (i.e. amount still owing) will be indicated.
         + pending (boolean, optional) - If true the transaction is created as pending and does not complete until captured. The transaction will be automatically voided if not captured.
         + metadata (object, optional) - Arbitrary data associated with the Transaction.
 
     + Body
 
-            {"id":"12b7865b-2056-456f-a","source":{"rail":"lightrail","valueId":"e8a966d4-0ffb-42c5-b"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"45633527-88d5-4ed3-a","source":{"rail":"lightrail","valueId":"7493b876-d3c6-4474-b"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
     
 + Response 201 (application/json)
 
@@ -911,7 +929,7 @@ Debit (remove an amount from) a Lightrail payment source.
 
     + Body
 
-            {"id":"12b7865b-2056-456f-a","transactionType":"debit","currency":"USD","createdDate":"2018-08-02T21:12:25.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"e8a966d4-0ffb-42c5-b","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"45633527-88d5-4ed3-a","transactionType":"debit","currency":"USD","createdDate":"2018-08-07T19:12:04.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"7493b876-d3c6-4474-b","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 + Response 409 (application/json)
 
@@ -948,7 +966,7 @@ Credit (add an amount to) a Lightrail payment destination.
 
     + Body
 
-            {"id":"d65b88e1-785b-42ff-8","destination":{"rail":"lightrail","valueId":"e8a966d4-0ffb-42c5-b"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"9438cff0-4b96-46a6-9","destination":{"rail":"lightrail","valueId":"7493b876-d3c6-4474-b"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
     
 + Response 201 (application/json)
 
@@ -956,7 +974,7 @@ Credit (add an amount to) a Lightrail payment destination.
 
     + Body
 
-            {"id":"d65b88e1-785b-42ff-8","transactionType":"credit","currency":"USD","createdDate":"2018-08-02T21:12:25.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"e8a966d4-0ffb-42c5-b","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"9438cff0-4b96-46a6-9","transactionType":"credit","currency":"USD","createdDate":"2018-08-07T19:12:04.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"7493b876-d3c6-4474-b","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":3000,"balanceChange":2500}],"paymentSources":null,"metadata":{"note":"Frequent buyer bonus"}}
 
 ### Transfer [POST /transactions/transfer]
 
@@ -975,13 +993,13 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
         + amount (number, required) - The amount to transfer, > 0.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + simulate (boolean, optional) - If true the transaction is simulated and no changes take place. If the transaction is repeated with simulate=false it is not guaranteed to behave the same way as the underlying Values can change.
-        + allowRemainder (boolean, optional) - If true the transaction will go through without all balance being debited, and the remainder indicated.
+        + allowRemainder (boolean, optional) - If true the transaction will go through using whatever amount is available: this might not cover the full amount of the transaction. The remainder (i.e. amount still owing) will be indicated.
         + pending (boolean, optional) - If true the transaction is created as pending and does not complete until captured. The transaction will be automatically voided if not captured.
         + metadata (object, optional) - Arbitrary data associated with the Transaction.
 
     + Body
 
-            {"id":"0b7be9dc-a2a9-4450-8","source":{"rail":"lightrail","valueId":"0f546d48-781e-4f55-8"},"destination":{"rail":"lightrail","valueId":"b77727cb-8aec-4111-8"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"fd117d8e-6219-4f1a-8","source":{"rail":"lightrail","valueId":"191f9597-d74a-438e-9"},"destination":{"rail":"lightrail","valueId":"bb472bb7-5a41-4399-8"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 201 (application/json)
 
@@ -990,7 +1008,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
         + transactionType (string, required) - `transfer`
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + steps (array[TransactionStep], required) - An array of transaction steps.
-        + remainder (number, required) - 
+        + remainder (number, required) - The amount still owing, if a remainder is allowed by setting `allowRemainder: true`.
         + simulated (boolean, optional) - True if the transaction was simulated.
         + createdDate (string, required) - Date when the Transaction was created.
         + pending (boolean, optional) - If true the transaction is created as pending and does not complete until captured. The transaction will be automatically voided if not captured.
@@ -998,7 +1016,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
 
     + Body
 
-            {"id":"0b7be9dc-a2a9-4450-8","transactionType":"transfer","currency":"USD","createdDate":"2018-08-02T21:12:29.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"0f546d48-781e-4f55-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"b77727cb-8aec-4111-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"fd117d8e-6219-4f1a-8","transactionType":"transfer","currency":"USD","createdDate":"2018-08-07T19:12:09.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"191f9597-d74a-438e-9","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":400,"balanceChange":-100},{"rail":"lightrail","valueId":"bb472bb7-5a41-4399-8","contactId":null,"code":null,"balanceBefore":500,"balanceAfter":600,"balanceChange":100}],"paymentSources":null,"metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 409 (application/json)
 
@@ -1028,7 +1046,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
 
     + Body
 
-            {"id":"12b7865b-2056-456f-a","transactionType":"debit","currency":"USD","createdDate":"2018-08-02T21:12:25.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"e8a966d4-0ffb-42c5-b","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"45633527-88d5-4ed3-a","transactionType":"debit","currency":"USD","createdDate":"2018-08-07T19:12:04.000Z","totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"7493b876-d3c6-4474-b","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000}],"paymentSources":null,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
 
 ### List Transactions [GET /transactions{?limit}{?transactionType}{?createdDate}{?maxCreatedDate}]
 
@@ -1412,7 +1430,7 @@ A Currency is a unit of money in Lightrail.  It can be a standard currency such 
 + discount (number) - The amount of discounts applies.
 + marketplace (TransactionTotalsMarketplace) - Marketplace totals calculated if any marketplace behaviour has been configured (by setting the LineItem `marketplaceRate`).
 + payable (number) - The amount payable.
-+ remainder (number) - The remainder of balance that could not be debited or charged.
++ remainder (number) - The amount still owing, if a remainder is allowed by setting `allowRemainder: true`.
 + subtotal (number) - The sum of all products, services and fees before tax or discounts.
 + tax (number) - The amount of tax to be collected.
 

--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -7,7 +7,7 @@ Your customer's account may represent value that can be used during checkout or 
 Like all other Lightrail value, accounts are backed by `Values`. 
 
 ### Getting Started with Accounts
-To get started with accounts, you first need to create a `Program` which defines the default parameters for you accounts.
+To get started with accounts, you first need to create a `Program` which defines the default parameters for your accounts.
 
 #### Creating a Program
 The `Program` will define the basic properties like currency for the accounts (`Values`) that will be created from it. 
@@ -18,19 +18,21 @@ Creating an account `Program`. Note, typically Programs are created through the 
 `POST https://api.lightrail.com/v2/programs`
 ```json
 {
-    "programId": "customer-accounts-usd",
+    "id": "customer-accounts-usd",
     "currency": "USD",
-    "access": "contactId",
     "name": "Accounts USD",
+    "discount": false,
+    "preTax": false,
     "tags": ["accounts-usd"]
 }
 ``` 
 
 #### Attributes
-Below is the list of attributes used when creating an Account Program.
- - **programId** (_required_): Unique idempotent ID for the Program.
+Below is the list of attributes commonly used when creating an Account Program. For full attribute details, see the [Programs endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/programs/create-program).
+ - **id** (_required_): Unique idempotent ID for the Program.
  - **currency** (_required_): Currency code. Can be a standard ISO form such as USD or CAD but can also be any branded currency, eg: `megabucks`.
- - **access** (_required_): Always use value `contactId` for creating account programs. This means the Values must be attached to a Customer.  
+ - **discount** (_optional_): Determines whether the Values in this Program represent a discount to the customer (default: `true`). Typically should be `false` for Account Programs.
+ - **preTax** (_optional_): Determines whether the Values in this Program are applied before taxes (default: `true`). Set this to `false` for Account Programs.
  - **name** (_optional_): A human-readable name for the Program.
  - **tags** (_optional_): Segmentation tags.
  - **metadata** (_optional_): Arbitrary data associated with the Program.
@@ -44,22 +46,22 @@ Request to create an account.
     "id": "account-h54sya3",
     "programId": "customer-accounts-usd",
     "contactId": "cus_123",
-    "value": 2500
+    "balance": 2500
 }
 ``` 
 
 #### Attributes
-Below is the list of attributes used when creating an account from a Program.
+Below is the list of attributes commonly used when creating an Account from a Program. For full attribute details, see the [Values endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/values/create-a-value).
 - **id** (_required_): Unique idempotent id for the Value.
 - **programId** (_required_): The programId of the Program this Value is in.
 - **contactId** (_required_): Unique ID for the Customer.
-- **value** (_optional_): An integer greater than or equal to 0 representing the initial value of the Account.
+- **balance** (_optional_): An integer greater than or equal to 0 representing the initial balance of the Account.
 
 ### Common Requests  
-Below are the most common requests made when interacting with accounts.
+Below are the most common requests made when interacting with Accounts.
 
 #### Crediting
-Crediting is used when adding value to an account.
+Crediting is used when adding value to an Account.
 
 `POST https://api.lightrail.com/v2/transactions/credit`
 ```json
@@ -67,7 +69,7 @@ Crediting is used when adding value to an account.
     "id": "unique-id-123",
     "destination": {
         "rail": "lightrail",
-        "id": "account-h54sya3"
+        "valueId": "account-h54sya3"
     },
     "amount": 2500,
     "currency": "USD",
@@ -78,18 +80,18 @@ Crediting is used when adding value to an account.
 }  
 ```
 
-See full credit endpoint [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/credit). 
+See full credit endpoint details [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/credit). 
 
 #### Debiting
 Debiting is used when removing value from an account.
 
-`POST https://api.lightrail.com/v2/transactions/credit`
+`POST https://api.lightrail.com/v2/transactions/debit`
 ```json
 {
     "id": "unique-id-123",
     "source": {
         "rail": "lightrail",
-        "id": "account-h54sya3"
+        "valueId": "account-u824rj0"
     },
     "amount": 2500,
     "currency": "XXX",
@@ -99,19 +101,19 @@ Debiting is used when removing value from an account.
 }
 ```
 
-See full debit endpoint [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/debit).
+See full debit endpoint details [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/debit).
 
 #### Using Accounts as a Payment Source in Checkout
-Checkout is done using the `/transactions/orders` endpoint. To use an account directly as a payment source simply provide the following in the sources property of the request. 
+Checkout uses the `/transactions/checkout` endpoint. To use an Account directly as a payment source simply provide the following in the sources property of the request. 
 
 ```json
 {
     "rail": "lightrail",
-    "id": "account-h54sya3"
+    "valueId": "account-h54sya3"
 }
 ```
 
-Alternatively, since the account is associated with the customer, you can directly use the `contactId` as a payment source. This will consider all `Values` associated with the customer.
+Alternatively, since the account is associated with the Contact, you can directly use the `contactId` as a payment source. This will consider all `Values` associated with the Contact.
 ```json
 {
     "rail": "lightrail",
@@ -119,7 +121,7 @@ Alternatively, since the account is associated with the customer, you can direct
 }
 ```
 
-See [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/process-an-order) for full documentation of `/transactions/orders` endpoint.
+See [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/checkout) for full documentation of the `/transactions/orders` endpoint.
 
 ### Support
 Want more information on your accounts or loyalty points use-case? [Contact us](mailto:hello@lightrail.com) any time if you have any questions, we're here to help. 

--- a/docs/drop-in-gift-cards.md
+++ b/docs/drop-in-gift-cards.md
@@ -1,0 +1,397 @@
+# Drop-in Gift Cards  
+
+## Quickstart
+Lightrail's Drop-in Gift Card solution makes it easy to offer gift cards to your customers. 
+Integrating into Lightrail is an easy process that can be completed in no more than a few hours.
+
+The solution is component based, using elements generated from our client-side library Lightrail UI.
+When your customers receive a gift card, they can easily redeem and apply the gift card value to their account.
+Your checkout process requires a simple update to accept payment from your customer accounts.
+
+### Getting Started
+[Sign up](https://www.lightrail.com/app/#/register) for a Lightrail account. 
+
+Note this quickstart assumes you are using Stripe to process payments: if you are using another payment processor and want to build a custom solution, please [contact us](mailto:hello@lightrail.com).
+
+We have preconfigured sample values for your [Drop-in Gift Card template](https://www.lightrail.com/app/#/cards/dropin) as a demo to help you get testing quickly. You can use all the default values to start, but if you are interested in running through an active test that includes a sample customer Gift Card redemption, you will need to update the **Email Claim Link** value in order to set up a testing url which you have access to. Please note: before taking your Drop-in components to production, you will want to be sure to update all the values to match your custom implementation.
+
+You can optionally edit the other configuration values of your Drop-in [template](https://www.lightrail.com/app/#/cards/dropin) within your Lightrail account to customize the appearance of components and gift card emails.
+Note: For development, toggle your Lightrail account to test mode, this will allow you to use [Stripe's test credit cards](https://stripe.com/docs/testing#cards).
+
+Also, before going live or to see test Stripe charges show up in your Stripe account, you'll need to connect your Stripe account on your account's integrations [page](https://www.lightrail.com/app/#/account/api). 
+
+If at any point you want to see a working example of the entire Drop-in Gift Card solution, check out our [sample app](https://github.com/Giftbit/stripe-integration-sample-webapp).
+
+### Authentication
+Create your Lightrail API key from the [Integrations](https://www.lightrail.com/app/#/account/api) section of your Lightrail account. 
+Your Lightrail API key is used to complete the server side requests from checkout, and also to generate Shopper Tokens which are passed into the Lightrail UI library for component authentication.  
+
+#### Shopper Tokens
+Shopper Tokens act like customer-specific API tokens to be used client-side in the drop-in components. 
+They are based on a unique customer identifier from your e-commerce system: the `shopperId`. This is what links the customer from your system to their account in Lightrail. 
+
+Shopper Tokens must be generated server side using one of our [client libraries](https://www.lightrail.com/docs/#client-libraries/client-libraries). (If you are working in a language that we don't currently offer a client library for, please [contact us](mailto:hello@lightrail.com) to discuss creating your own tokens.) 
+
+You'll also need your shared secret key from the [Integrations](https://www.lightrail.com/app/#/account/api) section of your account.  
+
+##### Generating a Shopper Token:
+
+First install the client library in the language of your choice:
+```javascript
+npm install lightrail-client
+```
+
+```php
+composer require lightrail/lightrail
+```
+
+```java
+<!-- add to your maven POM file -->
+<dependency>
+  <groupId>com.lightrail</groupId>
+  <artifactId>lightrail-client</artifactId>
+  <version>2.0.1</version>
+</dependency>
+```
+
+```ruby
+gem install lightrail_client
+```
+
+Creating a Shopper Token in server side code (this will be passed to the client-side components in Steps 1, 2, & 3): 
+```javascript
+const lightrail = require("lightrail-client");
+ 
+lightrail.configure({
+    apiKey: process.env.LIGHTRAIL_API_KEY,
+    sharedSecret: process.env.LIGHTRAIL_SHARED_SECRET
+});
+const shopperToken = lightrail.generateShopperToken({shopperId: "customer-id-from-your-system"});
+```
+
+```php
+// if using an autoload import statement the Lightrail library will load automatically
+
+\Lightrail\Lightrail::$apiKey = getenv("LIGHTRAIL_API_KEY");
+\Lightrail\Lightrail::$sharedSecret = getenv("LIGHTRAIL_SHARED_SECRET");
+$shopperToken = \Lightrail\LightrailShopperTokenFactory::generate(array("shopperId" => "customer-id-from-your-system"));
+```
+
+```java
+import com.lightrail.*
+
+// NOTE the Java client is currently inconsistent with other client libraries, it will be updated soon. 
+// For shopper token creation, pass in the shopperId from your system and the validity of the token in seconds
+Lightrail.apiKey = System.getenv("LIGHTRAIL_API_KEY");
+Lightrail.clientSecret = System.getenv("LIGHTRAIL_SHARED_SECRET");
+String shopperToken = LightrailClientTokenFactory.generate("customer-id-from-your-system", 600);
+```
+
+```ruby
+require 'lightrail_client'
+
+Lightrail.api_key = ENV["LIGHTRAIL_API_KEY"]
+Lightrail.shared_secret = ENV["LIGHTRAIL_SHARED_SECRET"]
+shopper_token = Lightrail::ShopperTokenFactory.generate({shopper_id: "customer-id-from-your-system"})
+```
+
+Note, usage of Lightrail UI components must be on authenticated pages as it requires a `shopperId`.
+You may decide whether you'd like your customers to be signed in to purchase gift cards. 
+If you'd like to allow gift card purchase from an unauthenticated page simply generate a Shopper Token with `shopperId: ""`. 
+
+Also, you can enable customers to pay using saved credit cards. See [below](#drop-in-gift-cards/enable-your-customers-to-pay-using-saved-credit-cards) details. 
+
+### Step 1: Selling Gift Cards
+The Gift Card Purchase Component allows your customers to purchase gift cards from your site. 
+Lightrail powers the entire gift card purchase and delivery flow. 
+
+![Gift Card Purchase Component](https://raw.githubusercontent.com/Giftbit/Lightrail-API-Docs/master/docs/assets/purchase-widget.png)
+
+What you see here is our fictional brand called Rocketship. Once set up with our Drop-in solution, you will see your branding instead.
+
+Adding the Gift Card Purchase Component:
+```html
+<html>
+    <head>
+        <!-- Include the Lightrail UI javascript library in your page header -->
+        <script src="https://embed.lightrail.com/dropin/v1/lightrail-ui.js"></script>
+    </head>
+    <body>
+        <div id="launch-button-container">
+            <!-- Container to inject launch button into -->
+        </div>
+        <script>
+            // Server generated shopperToken
+            var shopperToken = "{{shopperToken}}";
+            var lightrailUI = new LightrailUI(shopperToken);
+        
+            //Tell the component to inject a launch button in #launch-button-container
+            var options = {
+               launch_btn_container: "#launch-button-container",
+               launch_btn_label: "Buy Gift Card",
+               launch_btn_classname: "ltrl_button"
+            };
+            
+            //Initialize the component and mount / add it to the page
+            var cardPurchaseDialog = lightrailUI.components.cardPurchaseDialog(options);
+            cardPurchaseDialog.mount();
+        </script>
+    </body>
+</html>
+```
+
+Alternatively, you could use your own button:
+```html
+    <div class="launch-button-container">
+        <button id="buy-card-launch-button">Buy Gift Card</button>
+    </div>
+    <script>
+        //...
+        document.getElementById("buy-card-launch-button").addEventListener("click", function(){
+            cardPurchaseDialog.open();
+        });
+    </script>
+```
+
+The gift card is automatically delivered to the recipient in a branded email. The email includes a button to apply the gift card to the recipient's account.
+
+Note you will need to pass a server-generated Shopper Token into the above snippet - details [above](#drop-in-gift-cards/shopper-tokens). 
+
+#### Enable Your Customers to Pay Using Saved Credit Cards
+Allow your customers to pay with credit cards you've saved for them in Stripe. This will give the customer the option to pay using an existing card, if they have one, or to enter a new one. 
+
+<br/>
+
+![Purchase Using Saved Credit Card](https://raw.githubusercontent.com/Giftbit/Lightrail-API-Docs/master/docs/assets/saved-credit-cards.png)
+
+To enable this, you need to **provide the customer ID from Stripe** when you generate the Shopper Token. 
+
+How to pass in the `stripeCustomerId` during Shopper Token generation to enable the use of saved credit cards:
+```javascript
+const options = {
+    metadata: {stripeCustomerId: "cus_abcd1234"}
+};
+const shopperToken = lightrail.generateShopperToken({shopperId: "customer-id-from-your-system"}, options);
+
+```
+
+```php
+$shopperToken = \Lightrail\LightrailShopperTokenFactory::generate(array("shopperId" => "customer-id-from-your-system"), array("metadata" => array("stripeCustomerId" => "cus_abcd1234")));
+```
+
+```java
+// Not yet supported. Please let us know at hello@lightrail.com if you require this.  
+```
+
+```ruby
+shopper_token = Lightrail::ShopperTokenFactory.generate({shopper_id: "customer-id-from-your-system"}, {metadata: {stripeCustomerId: "cus_abcd1234"}})
+```
+
+### Step 2: Redeeming Gift Cards
+
+The Gift Card Redemption Component enables your customers to redeem gift cards to their account.
+
+<br/>
+
+![Gift Card Redemption Component](https://raw.githubusercontent.com/Giftbit/Lightrail-API-Docs/master/docs/assets/redemption-widget.png)
+
+When the recipient clicks the "apply to account" button in the email, they are taken to the redemption page indicated in your [Drop-in template](https://www.lightrail.com/app/#/cards/template).
+
+Adding the Gift Card Redemption Component:
+```html
+<html>
+    <head>
+        <!-- Include the Lightrail UI javascript library in your page header -->
+        <script src="https://embed.lightrail.com/dropin/v1/lightrail-ui.js"></script>
+    </head>
+    <body>
+            <div id="redemption-component"></div>
+            
+            <!-- Then add the following snippet to your redemption page -->
+            <script>
+                // Server generated shopperToken
+                var shopperToken = "{{shopperToken}}";
+                var lightrailUI = new LightrailUI(shopperToken);
+    
+                //Initialize our redemption component with a fullcode param so that it's auto-populated for the user
+                //It's a good idea to ensure your sites log-in / registration flows won't break this
+                var fullcodeValue = getUrlParamValue("fullcode");
+                var options = {
+                    fullcode: fullcodeValue
+                };
+                //Create the component and mount it inside of the redemption-component div
+                var redemption = lightrailUI.components.codeRedemption(options);
+                redemption.mount("#redemption-component");
+            </script>
+        </body>
+</html>
+```
+
+When a gift card is redeemed, the Redemption Component applies the gift card amount to the customer's account. If the customer does not have an account in Lightrail already, a new account will be created automatically.
+
+The Redemption Component uses a Shopper Token generated by your system to identify the customer and automatically apply the gift card to their account (see [above](#drop-in-gift-cards/shopper-tokens) for details about Shopper Tokens). Note, ensure your redemption page lives behind the login wall of your site so that the correct Shopper Token is generated by your system to identify the customer. 
+
+Next, your existing checkout process needs to be modified to allow the customer to pay with their account, which now contains the balance of the gift card they received. 
+
+### Step 3: Checkout
+
+#### Fetch and Display Account Balance
+
+Displaying Balances:
+```html
+<html>
+    <head>
+        <!-- Include the Lightrail UI javascript library in your page header -->
+        <script src="https://embed.lightrail.com/dropin/v1/lightrail-ui.js"></script>
+    </head>
+    <body>
+        <p>Your Account Balance: <span id="account-balance"></span></p>
+        <script>
+                // Server generated shopperToken
+                var shopperToken = "{{shopperToken}}";
+                var lightrailUI = new LightrailUI(shopperToken);
+                
+                //Fetch and Display a simply formatted balance in the account-balance span
+                lightrailUI.displayAccountBalance("#account-balance");
+                
+                //Alternatively, use fetchAccountBalance for more control
+                lightrailUI.fetchAccountBalance(function(balance){
+                    var formattedBalance = yourCustomFormatter(balance.balanceInCents, balance.currency);
+                    document.getElementById("account-balance").innerHTML = formattedBalance;
+                });
+        </script>
+    </body>
+</html>
+```
+
+This can be used anywhere it makes sense to display an account balance to your customer. 
+In the checkout, it gives your customer the information to choose whether or not to apply their account credit to their purchase.
+
+In our [sample webapp](https://github.com/Giftbit/stripe-integration-sample-webapp/blob/master/shared/views/checkout.html), the customer simply selects a checkbox to use their account credit.
+
+#### Accept Payment
+You will need to add a custom script to your checkout page to apply your customer's account credit to their purchase and accept a secondary payment method (such as a credit card) to cover any remaining balance. 
+
+This script will need to do the following: 
+
+- Let the customer choose whether to use their account credit
+- Adjust the split point accordingly: i.e. how much can be charged to their Lightrail account and how much to charge to their credit card
+- Call a charge simulation method on your server (see next section)
+- Post the charge (see next section)
+
+For an example, we recommend that you take a look at the [checkout page of our sample webapp](https://github.com/Giftbit/stripe-integration-sample-webapp/blob/master/shared/views/checkout.html). The sample checkout handles the logic of splitting the transaction between the customer's account credit and Stripe; it also loads a Stripe Elements form to handle the credit card portion of the payment if needed. (Templating in the example is done with Mustache but is not required.)
+
+#### Lightrail Stripe Clients
+
+Install the Lightrail Stripe client in the language of your choice to handle the split tender transactions:
+```javascript
+npm install lightrail-stripe
+```
+
+```php
+composer require lightrail/lightrail-stripe
+
+```
+
+```java
+<!-- your maven POM file -->
+<dependency>
+  <groupId>com.lightrail</groupId>
+  <artifactId>lightrail-stripe-client</artifactId>
+  <version>2.0.1</version>
+</dependency>
+```
+
+```ruby
+gem install lightrail_stripe
+```
+
+#### Post the Transaction (server side)
+The transaction is handled by backend methods using one of our client libraries (or methods that you [write yourself](https://github.com/Giftbit/Lightrail-API-Docs/blob/drop-in-gift-cards/use-cases/stripe-split.md)). You'll need to set up two endpoints to handle submissions from the custom form you added to [accept payment](#drop-in-gift-cards/accept-payment) to: 
+1. simulate charges (check the customer's account balance),
+1. post the charge and redirect your customer to a success page. 
+
+##### Simulate a Charge / Balance Check
+When your customer chooses to use their account credit, you need to see whether the account can cover the requested amount. In our [sample webapp](https://github.com/Giftbit/stripe-integration-sample-webapp/blob/master/shared/views/checkout.html), this is done by having the frontend call a `/simulate` endpoint that makes use of a method from one of our client libraries to simulate posting a charge to a Lightrail account. 
+
+
+Node example of simulate balance check:
+```javascript
+/**
+ * REST endpoint that simulates the charge and returns JSON.
+ */
+function simulate(req, res) {
+    const splitTenderParams = {
+        userSuppliedId: uuid.v4(),
+        nsf: false,
+        shopperId: req.body.shopperId,
+        currency: req.body.currency,
+        amount: req.body.amount
+    };
+
+    // Try to charge the whole thing to lightrail, and we'll use the amount that would actually get
+    // charged when we do the real transaction.
+    const lightrailShare = splitTenderParams.amount;
+
+    lightrailStripe.simulateSplitTenderCharge(splitTenderParams, lightrailShare)
+        .then(transaction => {
+            res.send(transaction.lightrailTransaction);
+        })
+        .catch(err => {
+            // You'll want to actually handle any errors that come back
+            console.error("Error simulating transaction", err);
+            res.status(500).send("Internal error");
+        });
+}
+```
+Use the Lightrail transaction value that comes back to set the parameters for actually posting the charge. 
+
+##### Post the Charge
+Our client libraries make it easy to post a split-tender charge where part of the transaction is covered by a Lightrail account, and part is covered by Stripe.  
+
+Node example of how to handle posting a charge:
+```javascript
+/**
+ * REST endpoint that performs the charge and returns HTML.
+ */
+function charge(req, res) {
+    const splitTenderParams = {
+        amount: req.body.orderTotal,      // From your cart/order object
+        currency: req.body.currency,      // From your cart/order/store config
+        source: req.body.source,          // Stripe payment 'source' or 'customer'
+        shopperId: req.body.shopperId,    // Lightrail contact identifier; see above
+        userSuppliedId: req.body.orderId       // Unique transaction identifier for idempotency
+    };
+
+    // Validate the amount to actually charge to Lightrail
+    const lightrailShare = req.body.lightrailAmount;
+    if (lightrailShare < 0) {
+        res.status(400).send("Invalid value for Lightrail's share of the transaction");
+    }
+
+    // Use the Lightrail-Stripe integration library to create the split tender charge
+    lightrailStripe.createSplitTenderCharge(splitTenderParams, lightrailShare, stripe)
+        .then(splitTenderCharge => {
+            // Redirect to your success page
+            res.render("checkoutComplete.html", {
+                lightrailTransactionValue: splitTenderCharge.lightrailTransaction ? splitTenderCharge.lightrailTransaction.value / -100 : 0,
+                stripeChargeValue: splitTenderCharge.stripeCharge ? splitTenderCharge.stripeCharge.amount / 100 : 0
+            });
+        })
+        .catch(err => {
+            // You'll want to actually handle any errors that come back
+            console.error("Error creating split tender transaction", err);
+            res.status(500).send("Internal error");
+        });
+}
+```
+
+At this point, the charge has been posted to both Lightrail and Stripe. You can handle post-checkout flow as you otherwise would. 
+
+## Customization and Advanced UI
+The appearance of components is fully customizable. Using Lightrail UI you can also attach event listeners to the components to respond to customer activity. For more information on this usage, see [Lightrail UI](#lightrail-ui).
+
+## Support
+Looking for an example? Check out our [sample app](https://github.com/Giftbit/stripe-integration-sample-webapp) which is a working example of the entire Drop-in Gift Card solution.
+
+Contact us any time at hello@lightrail.com —- we are here to help.

--- a/docs/drop-in-gift-cards.md
+++ b/docs/drop-in-gift-cards.md
@@ -9,13 +9,11 @@ When your customers receive a gift card, they can easily redeem and apply the gi
 Your checkout process requires a simple update to accept payment from your customer accounts.
 
 ### Getting Started
-[Sign up](https://www.lightrail.com/app/#/register) for a Lightrail account. 
+[Sign up](https://www.lightrail.com/app/#/auth/register) for a Lightrail account.
 
 Note this quickstart assumes you are using Stripe to process payments: if you are using another payment processor and want to build a custom solution, please [contact us](mailto:hello@lightrail.com).
 
 You will need configure a few settings to get started. 
-
-If at any point you want to see a working example of the entire Drop-in Gift Card solution, check out our [sample app](https://github.com/Giftbit/stripe-integration-sample-webapp).
 
 ### Step 0: Authentication & Configuration
 Create your Lightrail API key from the [Integrations](https://www.lightrail.com/app/#/account/api) section of your Lightrail account. 
@@ -84,9 +82,9 @@ This step is usually done in the web app (coming soon!) but currently must be do
 #### Shopper Tokens
 Shopper Tokens act like customer-specific API tokens to be used client-side in the drop-in components. They are based on a Contact's `id` stored in Lightrail.
 
-Shopper Tokens must be generated server side, for example using our [Node (Typescript/Javascript) Client Library](https://github.com/Giftbit/lightrail-client-javascript). (Coming soon: client libraries in Java, Ruby, PHP, and C#.)
+Shopper Tokens must be generated server side, for example using our [Node (Typescript/Javascript) Client Library](https://github.com/Giftbit/lightrail-client-javascript/tree/v2-client). (Coming soon: client libraries in Java, Ruby, PHP, and C#.)
 
-The current version of the Lightrail Javascript Client is under the alpha tag: `npm install lightrail-client@alpha`
+The current version of the Lightrail Javascript Client (^2.0.0) is under the alpha tag: `npm install lightrail-client@alpha`
 
 You'll also need the shared secret that you created earlier. You can retrieve it here: `GET https://api.lightrail.com/v1/storage/jwtSecret`
 

--- a/docs/gift-cards.md
+++ b/docs/gift-cards.md
@@ -15,65 +15,88 @@ How to create a Gift Card Program through the API. Note, typically Programs are 
 `POST https://api.lightrail.com/v2/programs`
 ```json
 {
-    "programId": "gift-cards-usd",
+    "id": "gift-cards-usd",
     "name": "Gift Cards USD",
     "currency": "USD",
-    "access": "secureCode",
     "minInitialBalance": 500,
     "maxInitialBalance": 100000,
+    "discount": false,
+    "preTax": false,
     "tags": ["giftCard"]
 }
 ``` 
 
 #### Attributes
-Below is the list of attributes used when creating an Account Program.
- - **programId** (_required_): Unique idempotent ID for the Program.
+Below is the list of attributes commonly used when creating a Gift Card Program. For full attribute details, see the [Programs endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/programs/create-program).
+ - **id** (_required_): Unique idempotent ID for the Program.
  - **name** (_optional_): A human-readable name for the Program.
  - **currency** (_required_): Currency code. Can be a standard ISO form such as USD or CAD but can also be any branded currency, eg: `megabucks`.
- - **access** (_required_): Always use value `secureCode` for creating account programs. This means the gift card will be created using a unique unguessable code.
- - **active** (_optional_): Whether the Value is active and can be used upon creation.
- - **minInitialValue** (_optional_): The minimum value the Value can be created with.
- - **maxInitialBalance** (_optional_): The maximum value the Value can be created with.  
- - **fixedInitialValues** (_optional_): A list of values the Value can be created with.  
+ - **active** (_optional_): Whether Values in this Program are active and can be used upon creation.
+ - **minInitialBalance** (_optional_): The minimum balance the Values in this Program can be created with.
+ - **maxInitialBalance** (_optional_): The maximum balance the Values in this Program can be created with.  
+ - **fixedInitialBalances** (_optional_): A list of exact balances the Values in this Program can be created with. Not set in combination with `minInitialBalance` and `maxInitialBalance`.
+ - **discount** (_optional_): Determines whether the Values in this Program represent a discount to the customer (default: `true`). Use `false` for Gift Card Programs.
+ - **preTax** (_optional_): Determines whether the Values in this Program are applied before taxes (default: `true`). Use `false` for Gift Card Programs.
  - **tags** (_optional_): Segmentation tags.
  - **metadata** (_optional_): Arbitrary data associated with the Program.
 
 ### Issuing a Gift Card
-Creating Gift Cards is easy. Below is the call to do this. 
-
 `POST https://api.lightrail.com/v2/values`
 ```json
 {
     "id": "gc-n6se54",
     "programId": "gift-cards-usd",
-    "value": 2500
+    "balance": 2500
 }
 ``` 
 
 #### Attributes
-Below is the list of attributes used when creating an Account from a Program.
-- **id** (_required_): Unique idempotent id for the Value.
+Below is the list of attributes commonly used when creating a Gift Card from a Program. For full attribute details, see the [Values endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/values/create-a-value).
+- **id** (_required_): Unique idempotent ID for the Value.
 - **programId** (_required_): The programId of the Program this Value is in.
-- **value** (_optional_): An integer greater than or equal to 0 representing the initial value of the Account.
+- **balance** (_optional_): An integer greater than or equal to 0 representing the initial balance of the Gift Card.
+- **code** (_optional_): Can by used by the customer to use the Gift Card as a payment source. 
+- **generateCode** (_optional_): Parameters to generate a secure code. To use the default length and character set, simply set to an empty object: `{}`. See the [reference](https://lightrailapi.docs.apiary.io/#reference/0/values/create-a-value) for usage details.
 
 ### Common Requests  
 Below are the most common requests made when interacting with Gift Cards.
 
 #### Retrieve Gift Code
-The unique code that's generated for a Gift Card must be retrieved via the following endpoint. It is not returned with the Gift Card (`Value`) for security purposes.
+The unique code that's generated for a Gift Card can be retrieved via the following endpoint. By default it is not returned with the Gift Card (`Value`) for security purposes.
 
-`GET https://api.lightrail.com/v2/values/<id>/code`
+`GET https://api.lightrail.com/v2/values/<id>?showCode=true`
 
-Example response:
+The response will be the same as the response returned for creating a Value, but with the full code displayed instead of only the last four characters:
 
 ```json 
 {
-    "code": "ABCDEFGHIJKLM"
+  "id": "gc-n6se54",
+  "currency": "USD",
+  "balance": 2500,
+  "uses": null,
+  "programId": "gift-cards-usd",
+  "issuanceId": null,
+  "contactId": null,
+  "code": "ABCDEF123456",
+  "isGenericCode": false,
+  "pretax": false,
+  "active": true,
+  "canceled": false,
+  "frozen": false,
+  "discount": false,
+  "discountSellerLiability": null,
+  "redemptionRule": null,
+  "valueRule": null,
+  "startDate": null,
+  "endDate": null,
+  "metadata": null,
+  "createdDate": "2018-08-02T21:12:24.000Z",
+  "updatedDate": "2018-08-02T21:12:24.000Z"
 }
-``` 
+```
 
 #### Using a Gift Card as a Payment Source in Checkout
-Checkout is done using the `/transactions/orders` endpoint. To use a Gift Card as a payment source simply provide the following in the sources property of the request. 
+Checkout uses the `/transactions/checkout` endpoint. To use a Gift Card as a payment source simply provide the following in the sources property of the request. 
 
 ```json
 {
@@ -82,7 +105,7 @@ Checkout is done using the `/transactions/orders` endpoint. To use a Gift Card a
 }
 ```
 
-See [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/process-an-order) for full documentation of `/transactions/orders` endpoint.
+See [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/checkout) for full documentation of the `/transactions/checkout` endpoint.
 
 ### Support
 Want more information on your gift card use-case? [Contact us](mailto:hello@lightrail.com) any time if you have any questions, we're here to help. 

--- a/docs/home.md
+++ b/docs/home.md
@@ -4,12 +4,12 @@ Lightrail makes it easy to create gift cards, manage customer account credit, ru
 The checkout solution allows you to submit a customer's shopping cart along with a list of sources to pay for the order. The payment sources can be value held by that customer in Lightrail along with external value, such as a credit card, to pay for any remainder of the order. Lightrail takes care of the complexity of this split-tender transaction, ensuring value in Lightrail and external credit cards are charged the correct amount.
 
 ### Checkout with Lightrail
-Checkout is done by creating an order through the `/transactions/orders` endpoint. Let's look at an example. 
+Checkout transactions use the `/transactions/checkout` endpoint. Let's look at an example. 
 
-Suppose you're running an ad campaign for 20% all orders that use the promotion code "EASYMONEY". 
+Suppose you're running an ad campaign for 20% off all orders that use the promotion code "EASYMONEY". 
 Perhaps a customer who has $20 account credits visits your store, enters the promotion code, and wants to purchase a $30 product. Using the `orders` endpoint it is easy to complete the payment for this entire transaction in a single request.
 
-**Request**: `POST /transactions/orders`
+**Request**: `POST /transactions/checkout`
 ```json
 {
     "id": "unique-id-123",
@@ -19,6 +19,7 @@ Perhaps a customer who has $20 account credits visits your store, enters the pro
             "productId": "pid_1",
             "unitPrice": 3000,
             "taxRate": 0.05,
+            "quantity": 1
         }
     ],
     "sources": [
@@ -28,23 +29,23 @@ Perhaps a customer who has $20 account credits visits your store, enters the pro
         },
         {
             "rail": "lightrail",
-            "publicCode": "EASYMONEY"
+            "code": "EASYMONEY"
         },
         {
             "rail": "stripe",
-            "cardToken": "tok_12345"
+            "source": "tok_12345"
         }
     ]
 }
 ```       
 
-You can see `lineItems` contains the basic shopping cart information. 
+The `lineItems` array contains the details of the items in the order. 
 
-Also, note the `sources` property in the request. It includes three sources, two of which are value stored in Lightrail, the other is a tokenized card from Stripe.
+Also, note the `sources` property in the request. It includes three sources, two of which are Values stored in Lightrail, the other is a tokenized card from Stripe.
 
 - `"contactId": "cus_123"`: uses any value associated with that customer in Lightrail. 
 - `"code: "EASYMONEY"`: represents the promotion code entered during checkout.
-- `"cardToken": "tok_12345"`: tokenized card using Stripe elements.  
+- `"source": "tok_12345"`: tokenized card using Stripe elements.  
  
 **Response**: `200 OK`
 ```json
@@ -55,17 +56,19 @@ Also, note the `sources` property in the request. It includes three sources, two
         "subtotal": 3000,
         "tax": 120,
         "discount": 600,
-        "payable": 2520
+        "payable": 2520,
+        "remainder": 0
     },
     "lineItems": [
         {
             "productId": "pid_1",
             "unitPrice": 3000,
             "taxRate": 0.05,
+            "quantity": 1,
             "lineTotal": {
-                "price": 3000,
-                "discount": 600,
+                "subtotal": 3000,
                 "taxable": 2400,
+                "discount": 600,
                 "tax": 120,
                 "payable": 2520
             }
@@ -74,20 +77,46 @@ Also, note the `sources` property in the request. It includes three sources, two
     "steps": [
         {
             "rail": "lightrail",
-            "id": "easymoney-promo",
-            "amount": -600, 
+            "valueId": "easymoney-promo",
+            "code": "EASYMONEY",
+            "contactId": null,
+            "balanceBefore": 0,
+            "balanceAfter": 0,
+            "balanceChange": -600, 
             "discount": true
         },
         {
             "rail": "lightrail",
-            "id": "cus_123-account",
-            "amount": -2000, 
+            "valueId": "cus_123-account",
+            "contactId": "cus_123",
+            "code": null,
+            "balanceBefore": 4500, 
+            "balanceAfter": 2500, 
+            "balanceChange": -2000, 
             "discount": false
         },
         {
             "rail": "stripe",
             "chargeId": "ch_abcde",
-            "amount": -520
+            "amount": -520,
+            "charge": {
+                "id": "ch_abcde",
+                // ...full Stripe charge response: for an example, see the [endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/transactions/checkout)
+            }
+        }
+    ],
+    "paymentSources": [
+        {
+            "rail": "lightrail",
+            "contactId": "cus_123"
+        },
+        {
+            "rail": "lightrail",
+            "code": "EASYMONEY"
+        },
+        {
+            "rail": "stripe",
+            "source": "tok_12345"
         }
     ]
 } 
@@ -98,8 +127,8 @@ As you can see, Lightrail handles the complexity of applying the promotion, calc
 Lightrail returns a summary and detailed information of the transaction so that it's easy to display a breakdown to the customer. 
 
 ### Checkout Payment Sources
-The `sources` property in the `orders` endpoint contains a list of payment sources. 
-A source consists of an object with a `rail` identifier along with some additional data. There are currently two payment rails: `lightrail` and `stripe`. Support for more credit card processors such as BrainTree and Square is coming soon!
+The `sources` property in the `checkout` endpoint contains a list of payment sources. 
+A `source` consists of an object with a `rail` identifier along with some additional data. See the [full endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/transactions/checkout) for details. 
 
 #### Rail: Lightrail
 A source with `"rail": "lightrail"` means the value is stored in Lightrail. 
@@ -108,11 +137,11 @@ A source with `"rail": "lightrail"` means the value is stored in Lightrail.
 Value stored in Lightrail, whether it represents a gift card, account credits or points, or a promotional offer for a discount, are stored as `Values`.   
 Different types of value are represented by modifying the properties of `Values`.
 
-The way `Values` are passed into the `sources` property of the `orders` resource depends on what type of value it is.
+The way `Values` are passed into the `sources` property of the `checkout` endpoint depends on what type of value it is.
 
 ##### `contactId`
-Some value may be attached directly to a `Customer` (see the [create customer documentation](https://lightrailapi.docs.apiary.io/#reference/0/customers/create-customer) for details on creating `Customers`).
-For example account credits or promotions are commonly attached directly to a `Customer`. 
+Some value may be attached directly to a `Contact` (see the [create Contact documentation](https://lightrailapi.docs.apiary.io/#reference/0/contacts/create-a-contact) for details on creating `Contacts`).
+For example account credits or promotions are commonly attached directly to a `Contact`. 
 
 Usage:
 ```json
@@ -122,50 +151,55 @@ Usage:
 }
 ```     
 
-This will cause the `orders` endpoint to consider all `Values` associated with that customer and will resolve the complexity of applying them to the order in the correct order. 
+This will cause the `checkout` endpoint to consider all `Values` attached to that customer and will resolve the complexity of charging them in the correct order. 
 
-##### `secureCode`       
-A `secureCode` is a unique-unguessable code and is most commonly used by gift cards and unique promotion codes. 
+##### `code`
+A Value can be identified by a `code`. A `code` can be secret and meant for use by one person (commonly used for gift cards and unique promotion codes), or it can be generic - a human-readable code such as "EASYMONEY" that can be shared publicly through many channels (ads, flyers, etc). 
 
 Usage:
+
+Secret codes and generic codes are passed in the same way in the request. Generic codes will be displayed in full in the response, and only the last four characters of a secret code will be returned. 
+
 ```json
 {
     "rail": "lightrail",
-    "secureCode": "UNIQUE-UNGUESSABLE-CODE"
+    "code": "UNIQUE-UNGUESSABLE-CODE"
 }
-``` 
+```
 
-##### `publicCode`
-A `publicCode` is usually a human-readable code like `EASYMONEY` which would be displayed through various channels (ads, etc) to many users.
-
-Usage:
+Response: 
 ```json
 {
-    "rail": "lightrail",
-    "publicCode": "EASYMONEY"
+    "paymentSources": [
+        {
+            "rail": "lightrail",
+            "code": "...CODE"
+        }
+    ]
 }
-```  
+```
+
 
 #### Rail: Stripe
-The `"rail": "stripe"` is used when payment from a credit card is required for the `order`. 
+The `"rail": "stripe"` is used when payment from a credit card is required for the transaction. 
 You must OAuth your Stripe account with Lightrail so that Lightrail can charge the credit card on your behalf using [Stripe Connect](https://stripe.com/connect).
 
 Usage:
 ```json
 {
     "rail": "stripe",
-    "cardToken": "tok_12345"
+    "source": "tok_12345"
 }
 ```  
 
-The `cardToken` is a tokenized credit card, created from Stripe Elements.
+The `source` is a tokenized credit card, created from Stripe Elements.
 
 ### Getting Started
 See our examples below to get started with:
 
-- [Gift cards](https://localhost:8181/docs/#gift-cards/gift-cards)
-- [Accounts and loyalty points](https://localhost:8181/docs/#accounts/accounts-and-points)
-- [Promotions](https://localhost:8181/docs/#discounts/promotions) 
+- [Gift cards](https://www.lightrail.com/docs/#gift-cards/gift-cards)
+- [Accounts and loyalty points](https://www.lightrail.com/docs/#accounts/accounts-and-points)
+- [Promotions](https://www.lightrail.com/docs/#discounts/promotions)
 - [Checkout](https://lightrailapi.docs.apiary.io/#reference/0/transactions/process-an-order)
  
 [Contact us](mailto:hello@lightrail.com) any time if you have any questions, we're here to help. 

--- a/docs/promotions.md
+++ b/docs/promotions.md
@@ -4,8 +4,6 @@ Lightrail enables a wide variety of promotion use-cases. A few common examples a
  2. A site wide promotion code that can be entered during checkout.
  3. Unique promotion code delivered to a potential customer.  
  
-These types of promotions are differentiated primarily based on the `accessType` property.
-In addition to how the promotion is accessed, they type of value they hold can also differ. 
 Promotions can be valid for a number of dollars or points off, but they can also represent a percent discount.
 These variations are all determined by properties on the `Value` which represents the promotion.
 
@@ -15,20 +13,19 @@ To get started with promotions, you first need to create a `Program` which defin
 Let's look at an example of creating a sign-up promotion which will be attached to new sign-ups.  
 
 #### Creating a Program for a Customer Promotion
-The `Program` will define the basic properties like `currency`, `accessType` and `value` for the (`Values`) that will be created from it. 
-Below are the required and optional attributes needed for creating a `Program` for a promotion.
+The `Program` will define the basic properties for the promotional `Values` that will be created from it. 
+Below are the required and common optional attributes needed for creating a `Program` for promotions. For full attribute details, see the [Programs endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/programs/create-program).
 
-Example of creating a `Program` for a promotion that will be directly attached to a customer. 
+Example of creating a `Program` for a $5 promotion:  
 
 `POST https://api.lightrail.com/v2/programs`
 ```json
 {
-    "programId": "sign-up-promotion",
+    "id": "sign-up-promotion",
     "name": "Spring Promotion USD",
     "currency": "USD",
-    "access": "contactId",
-    "preTax": false,
     "discount": true,
+    "preTax": false,
     "fixedInitialBalances": [
         500
     ],
@@ -37,20 +34,22 @@ Example of creating a `Program` for a promotion that will be directly attached t
 ``` 
 
 #### Attributes
-Below is the list of attributes used when creating a Promotion Program.
- - **programId** (_required_): Unique idempotent ID for the Program.
+Below is the list of attributes commonly used when creating a Promotion Program. For full attribute details, see the [Programs endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/programs/create-program).
+ - **id** (_required_): Unique idempotent ID for the Program.
  - **currency** (_required_): Currency code. Can be a standard ISO form such as USD or CAD but can also be any branded currency, eg: `megabucks`.
- - **access** (_required_): In this case use `contactId` for attaching to a customer.
- - **discount** (_required_): Set to `true`. 
- - **minInitialBalance** (_optional_): The minimum value the Value can be created with.
- - **maxInitialBalance** (_optional_): The maximum value the Value can be created with.  
- - **fixedInitialValues** (_optional_): A list of values the Value can be created with.    
  - **name** (_optional_): A human-readable name for the Program.
+ - **discount** (_optional_): Determines whether the Values in this Program represent a discount to the customer. Set to `true` (default: `true`). 
+ - **preTax** (_optional_): Determines whether the Values in this Program are applied before taxes (default: `true`). 
+ - **minInitialBalance** (_optional_): The minimum balance the Values in this Program can be created with.
+ - **maxInitialBalance** (_optional_): The maximum balance the Values in this Program can be created with.  
+ - **fixedInitialBalances** (_optional_): A list of exact balances the Values in this Program can be created with. 
+ - **valueRule**: A Value Rule controlling the effective balance of the Value in a Checkout - for example, a percent-off discount. See the [endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/programs/create-program) for usage details.
+ - **redemptionRule**: A Redemption Rule controlling when the Value can be used in checkout. See the [endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/programs/create-program) for usage details.
  - **tags** (_optional_): Segmentation tags.
  - **metadata** (_optional_): Arbitrary data associated with the Program.
 
-### Request to add the Promotion to a Customer 
-Request to add a promotion to a customer.  
+### Attaching the Promotion to a Contact 
+This request attaches a new Value to a Contact, so that this promotion will be applied automatically when the Contact is specified as a payment source in checkout (see next section).
 
 `POST https://api.lightrail.com/v2/values`
 ```json
@@ -58,20 +57,20 @@ Request to add a promotion to a customer.
     "id": "cus_123-sign-up-promotion",
     "programId": "sign-up-promotion",
     "contactId": "cus_123",
-    "value": 500
+    "balance": 500
 }
 ``` 
 
 #### Attributes
-Below is the list of attributes used when creating an account from a Program.
+Below is the list of attributes used when creating a promotional Value from a Program. For full Value creation attribute details, see the [Values endpoint reference](https://lightrailapi.docs.apiary.io/#reference/0/values/create-a-value).
 - **id** (_required_): Unique idempotent id for the Value.
 - **programId** (_required_): The programId of the Program this Value is in.
-- **contactId** (_required_): Unique ID for the Customer.
-- **value** (_required_): In this case, must match the value defined in `fixedInitialValues`. 
+- **contactId** (_required_): Unique ID for the Contact.
+- **balance** (_required_): In this case, must match the amount set in `fixedInitialBalances`. 
 
 #### Using the Promotion as a Payment Source in Checkout
-Checkout is done using the `/transactions/orders` endpoint. Since the account is associated with the customer, you can directly use the `contactId` as a payment source. 
-This will automatically use the promotion along with any other Values associated with the customer.  
+Checkout uses the `/transactions/checkout` endpoint. Since the promotion is associated with the customer, you can directly use the `contactId` as a payment source. 
+This will automatically use the promotion along with any other Values attached to the Contact.  
 
 ```json
 {
@@ -80,7 +79,7 @@ This will automatically use the promotion along with any other Values associated
 }
 ```
 
-See [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/process-an-order) for full documentation of `/transactions/orders` endpoint.
+See [here](https://lightrailapi.docs.apiary.io/#reference/0/transactions/checkout) for full documentation of the `/transactions/checkout` endpoint.
 
 ### Support
 Want more information on promotions? [Contact us](mailto:hello@lightrail.com) any time if you have any questions, we're here to help. 


### PR DESCRIPTION
Updates to guides (quickstarts/etc):
- `order` -> `checkout`
- remove `accessType`
- update how IDs are specified
- drop-in updates: client libs out; embed link updated; manual calls for things that will be done in the webapp

Apiary updates:
- add section GET Value by Code
- fixed `issuing-value` links (now under Programs)
- improved remainder explanation
- fix: Program response attributes were Contact attributes