### PR TITLE
Added one promotion per transaction redemptionRule to documentation.

### DIFF
--- a/feature-deep-dive/redemption-and-balance-rules.md
+++ b/feature-deep-dive/redemption-and-balance-rules.md
@@ -1,5 +1,9 @@
 # Redemption Rules and Balance Rules
-Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. Redemption Rules determine if a Value can be used and evaluate to true or false. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Rules are typically used for promotions and represent a discount to the customer. Let's look at a few common examples.  
+Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. 
+
+Redemption Rules evaluate to true or false and determine if the Value their set on can be used in Checkout; they do not affect whether other Values can be used in Checkout since the other Value's Redemption Rules determine that.  
+
+Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Rules are typically used for promotions and represent a discount to the customer. Let's look at a few common examples.  
 
 **Example 1: $5 off transactions over $100** 
 
@@ -41,7 +45,7 @@ Create Value request - `POST https://api.lightrail.com/v2/values`:
 ```
 
 ## How Rules Work
-Balance and Redemption Rules are evaluated for each line item during checkout. Rules operate on a Rule Context which contains the current line item (`currentLineItem`), the transaction totals (`totals`), a list of all of the line items in the transaction (`lineItems`), the transaction metadata (`metadata`), and the current Value being applied (`value`). Values are applied one by one during checkout.
+Balance and Redemption Rules are evaluated for each line item during checkout. Rules operate on a Rule Context, described below. Redemption Rules Values are applied one by one during checkout and determine whether the Value their set on can be applied. 
 
 ### Rule Context 
 ```json
@@ -102,15 +106,15 @@ If you want to limit promotions (Values with `discount: true`) to one promotion 
 }
 ``` 
 
- ## Limiting to One Promotion per Line Item
- If you want to limit promotions (Values with `discount: true`) to one promotion per `lineItem` you must include the following `redemptionRule` on all of your promotions.
- ```json
- {
-     "redemptionRule": {
-         "rule": "currentLineItem.lineTotal.discount == 0",
-         "explanation": "Limited to 1 promotion per line item."
-     }
- }
+## Limiting to One Promotion per Line Item
+If you want to limit promotions (Values with `discount: true`) to one promotion per `lineItem` you must include the following `redemptionRule` on all of your promotions.
+```json
+{
+    "redemptionRule": {
+        "rule": "currentLineItem.lineTotal.discount == 0",
+        "explanation": "Limited to 1 promotion per line item."
+    }
+}
  ``` 
 
 ## Examples Continued

--- a/feature-deep-dive/redemption-and-balance-rules.md
+++ b/feature-deep-dive/redemption-and-balance-rules.md
@@ -1,5 +1,5 @@
 # Redemption Rules and Balance Rules
-Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. Redemption Rules evaluate to true or false and determine if the Value their set on can be used in Checkout; they do not affect whether other Values can be used in Checkout since the other Value's Redemption Rules determine that. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Balance Rules and Redemption Rules are typically used for promotions that represent a discount to the customer.   
+Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. Redemption Rules evaluate to true or false and determine if the Value their set on can be used in Checkout; they do not affect whether other Values can be used since the other Value's Redemption Rules determine that. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Balance Rules and Redemption Rules are typically used for promotions that represent a discount to the customer.   
 
 **Example 1: $5 off transactions over $100** 
 

--- a/feature-deep-dive/redemption-and-balance-rules.md
+++ b/feature-deep-dive/redemption-and-balance-rules.md
@@ -1,9 +1,5 @@
 # Redemption Rules and Balance Rules
-Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. 
-
-Redemption Rules evaluate to true or false and determine if the Value their set on can be used in Checkout; they do not affect whether other Values can be used in Checkout since the other Value's Redemption Rules determine that.  
-
-Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Rules are typically used for promotions and represent a discount to the customer. Let's look at a few common examples.  
+Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. Redemption Rules evaluate to true or false and determine if the Value their set on can be used in Checkout; they do not affect whether other Values can be used in Checkout since the other Value's Redemption Rules determine that. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Balance Rules and Redemption Rules are typically used for promotions that represent a discount to the customer.   
 
 **Example 1: $5 off transactions over $100** 
 

--- a/feature-deep-dive/redemption-and-balance-rules.md
+++ b/feature-deep-dive/redemption-and-balance-rules.md
@@ -41,7 +41,7 @@ Create Value request - `POST https://api.lightrail.com/v2/values`:
 ```
 
 ## How Rules Work
-Values are applied one by one to each line item in turn during checkout. Balance Rules and Redemption Rules are evaluated for each line item during checkout. Rules operate on a rule context, described below. Redemption Rules only determine whether the Value they're set on can be applied and do not affect whether other Values can be applied. 
+Values are applied one by one to each line item in turn during checkout. Balance Rules and Redemption Rules are evaluated for each line item. Rules operate on a rule context, described below. Redemption Rules only determine whether the Value they're set on can be applied and do not affect whether other Values can be applied. 
 
 ### Rule Context 
 ```json
@@ -91,7 +91,10 @@ Values are applied one by one to each line item in turn during checkout. Balance
 
 You can think of the Rule Context as a simple map which the Rules evaluate on.
 
-## Limiting to One Promotion per Transaction
+## Limiting How Many Promotions Can Be Applied to Checkout 
+By default, any number of Values can be applied to a checkout Transaction. If you want to limit promotions (Values with discount: true) to one promotion per Transaction or one per line item you must include the corresponding Redemption Rule on all of your promotions. Remember that each Value's applicability is determined by its own Redemption Rule and Balance Rule and not affected by rules set on other Values.
+
+### Limiting to One Promotion per Checkout
 If you want to limit promotions (Values with `discount: true`) to one promotion per Transaction you must include the following `redemptionRule` on all of your promotions.
 ```json
 {
@@ -102,7 +105,7 @@ If you want to limit promotions (Values with `discount: true`) to one promotion 
 }
 ``` 
 
-## Limiting to One Promotion per Line Item
+### Limiting to One Promotion per Line Item
 If you want to limit promotions (Values with `discount: true`) to one promotion per `lineItem` you must include the following `redemptionRule` on all of your promotions.
 ```json
 {

--- a/feature-deep-dive/redemption-and-balance-rules.md
+++ b/feature-deep-dive/redemption-and-balance-rules.md
@@ -41,7 +41,7 @@ Create Value request - `POST https://api.lightrail.com/v2/values`:
 ```
 
 ## How Rules Work
-Balance and Redemption Rules are evaluated for each line item during checkout. Rules operate on a Rule Context, described below. Redemption Rules Values are applied one by one during checkout and determine whether the Value their set on can be applied. 
+Balance and Redemption Rules are evaluated for each line item during checkout. Rules operate on a Rule Context, described below. Values are applied one by one during Checkout. Redemption Rules only determine whether the Value their set on can be applied and do not affect whether other Values can be applied. 
 
 ### Rule Context 
 ```json

--- a/feature-deep-dive/redemption-and-balance-rules.md
+++ b/feature-deep-dive/redemption-and-balance-rules.md
@@ -1,5 +1,5 @@
 # Redemption Rules and Balance Rules
-Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during Checkout. Redemption Rules evaluate to true or false and determine if the Value their set on can be applied; they do not affect whether other Values can be used since the other Value's Redemption Rules determine that. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Balance Rules and Redemption Rules are typically used for promotions that represent a discount to the customer.   
+Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. A Value's Redemption Rule evaluates to true or false and determines if that Value can be applied. This does not affect whether other Values can be used since each Value's own Redemption Rule determines whether or not it can be applied. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number in the context of a particular Transaction. Balance Rules and Redemption Rules are typically used for promotions that represent a discount to the customer.   
 
 **Example 1: $5 off transactions over $100** 
 
@@ -41,7 +41,7 @@ Create Value request - `POST https://api.lightrail.com/v2/values`:
 ```
 
 ## How Rules Work
-Balance and Redemption Rules are evaluated for each line item during Checkout. Rules operate on a Rule Context, described below. Values are applied one by one during Checkout. Redemption Rules only determine whether the Value their set on can be applied and do not affect whether other Values can be applied. 
+Values are applied one by one to each line item in turn during checkout. Balance Rules and Redemption Rules are evaluated for each line item during checkout. Rules operate on a rule context, described below. Redemption Rules only determine whether the Value they're set on can be applied and do not affect whether other Values can be applied. 
 
 ### Rule Context 
 ```json
@@ -151,7 +151,7 @@ Create Value request - `POST https://api.lightrail.com/v2/values`:
     "discount": true
 }
 ```
-Values are applied to Checkout item by item. The Rule Context property `value.balanceChange` keeps track of the total amount paid by the Value as it gets applied to each item. Note, it is a negative since it represents the change in balance. Also, to enforce that at most one promotion is applied to each line item the redemptionRule `"currentLineItem.lineTotal.discount == 0"` must be set on all promotions.  
+Values are applied to checkout item by item. The Rule Context property `value.balanceChange` keeps track of the total amount paid by the Value as it gets applied to each item. Note, it is a negative since it represents the change in balance. Also, to enforce that at most one promotion is applied to each line item the redemptionRule `"currentLineItem.lineTotal.discount == 0"` must be set on all promotions.  
 
 **25% off transactions over $100 and limited to 1 promotion per transaction**
 

--- a/feature-deep-dive/redemption-and-balance-rules.md
+++ b/feature-deep-dive/redemption-and-balance-rules.md
@@ -1,5 +1,5 @@
 # Redemption Rules and Balance Rules
-Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during checkout. Redemption Rules evaluate to true or false and determine if the Value their set on can be used in Checkout; they do not affect whether other Values can be used since the other Value's Redemption Rules determine that. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Balance Rules and Redemption Rules are typically used for promotions that represent a discount to the customer.   
+Redemption Rules and Balance Rules are extra conditions placed on Values that are evaluated during Checkout. Redemption Rules evaluate to true or false and determine if the Value their set on can be applied; they do not affect whether other Values can be used since the other Value's Redemption Rules determine that. Balance Rules enable more advanced balance behaviour, such as percent off, and evaluate to a number. Balance Rules and Redemption Rules are typically used for promotions that represent a discount to the customer.   
 
 **Example 1: $5 off transactions over $100** 
 
@@ -41,7 +41,7 @@ Create Value request - `POST https://api.lightrail.com/v2/values`:
 ```
 
 ## How Rules Work
-Balance and Redemption Rules are evaluated for each line item during checkout. Rules operate on a Rule Context, described below. Values are applied one by one during Checkout. Redemption Rules only determine whether the Value their set on can be applied and do not affect whether other Values can be applied. 
+Balance and Redemption Rules are evaluated for each line item during Checkout. Rules operate on a Rule Context, described below. Values are applied one by one during Checkout. Redemption Rules only determine whether the Value their set on can be applied and do not affect whether other Values can be applied. 
 
 ### Rule Context 
 ```json
@@ -151,7 +151,7 @@ Create Value request - `POST https://api.lightrail.com/v2/values`:
     "discount": true
 }
 ```
-Values are applied to checkout item by item. The Rule Context property `value.balanceChange` keeps track of the total amount paid by the Value as it gets applied to each item. Note, it is a negative since it represents the change in balance. Also, to enforce that at most one promotion is applied to each line item the redemptionRule `"currentLineItem.lineTotal.discount == 0"` must be set on all promotions.  
+Values are applied to Checkout item by item. The Rule Context property `value.balanceChange` keeps track of the total amount paid by the Value as it gets applied to each item. Note, it is a negative since it represents the change in balance. Also, to enforce that at most one promotion is applied to each line item the redemptionRule `"currentLineItem.lineTotal.discount == 0"` must be set on all promotions.  
 
 **25% off transactions over $100 and limited to 1 promotion per transaction**
 


### PR DESCRIPTION
# Updates
- Added one promotion per transaction redemptionRule to documentation. Made it more prominent than 1 transaction per lineItem since it's a more intuitive / safer default.
- Added value.metadata to RuleContext since it's there and the new referral code documenation relies on this property. 