### PR TITLE
Updated verify signature method.

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -73,7 +73,7 @@ export function verifySignature(signatureHeader: string, secret: string, payload
         .update(payload)
         .digest("hex");
     // constant time string comparison to prevent timing attacks (see: https://codahale.com/a-lesson-in-timing-attacks) 
-    return eventSignatures.reduce((prev, cur) => prev || crypto.timingSafeEqual(Buffer.from(cur), Buffer.from(signature)), false);
+    return eventSignatures.reduce((prev, cur) => prev || (cur.length === signature.length && crypto.timingSafeEqual(Buffer.from(cur), Buffer.from(signature))), false);
 }
 ````
 


### PR DESCRIPTION
Timing safe equal exceptions if the string lengths you're comparing differ.