### PR TITLE
Whitespace handling updates

### DIFF
--- a/apiary-sources/data-structures/CodeGeneration.md
+++ b/apiary-sources/data-structures/CodeGeneration.md
@@ -1,5 +1,5 @@
 ## CodeGeneration (object)
 + length (number, required) - The number of random characters in the code.  This number must be at least 5 to accommodate a reasonable amount of randomness.
 + charset (string, optional) - The set of characters to use for the random part of the code.  Defaults to all numbers and upper case letters.
-+ prefix (string, optional) - Text prepended before the random characters in the code.
-+ suffix (string, optional) - Text appended after the random characters in the code.
++ prefix (string, optional) - Text prepended before the random characters in the code. May not contain leading whitespace.
++ suffix (string, optional) - Text appended after the random characters in the code. May not contain trailing whitespace.

--- a/apiary-sources/data-structures/TransactionParty.md
+++ b/apiary-sources/data-structures/TransactionParty.md
@@ -1,6 +1,6 @@
 ## LightrailTransactionParty (object)
 + rail (string, required) - The payment rail: `lightrail`. Must be used in combination with one of the following identifiers.
-+ code (string) - The code of a Gift Card or Promotion.
++ code (string) - The code of a Gift Card or Promotion. {{whitespace.valueCodeNote}}
 + contactId (string) - A Contact's ID.  This is shorthand for all Values that a Contact is associated with.
 + valueId (string) - A Value's ID.
 

--- a/apiary-sources/endpoints/contacts-create.md
+++ b/apiary-sources/endpoints/contacts-create.md
@@ -6,7 +6,7 @@
             {{header.authorization}}
         
     + Attributes
-        + id (string, required) - {{contact.id}}  {{contact.idPurpose}}
+        + id (string, required) - {{contact.id}}  {{contact.idPurpose}} {{whitespace.id}}
         + firstName (string, optional) - {{contact.firstName}}
         + lastName (string, optional) - {{contact.lastName}}
         + email (string, optional) - {{contact.email}}

--- a/apiary-sources/endpoints/currencies-create.md
+++ b/apiary-sources/endpoints/currencies-create.md
@@ -6,7 +6,7 @@
             {{header.authorization}}
         
     + Attributes
-        + code (string, required) - {{currency.code}}
+        + code (string, required) - {{currency.code}} {{whitespace.code}}
         + name (string, required) - {{currency.name}}
         + symbol (number, required) - {{currency.symbol}}
         + decimalPlaces (number, required) - {{currency.decimalPlaces}}

--- a/apiary-sources/endpoints/programs-create.md
+++ b/apiary-sources/endpoints/programs-create.md
@@ -6,7 +6,7 @@
             {{header.authorization}}
         
     + Attributes
-        + id (string, required) - {{program.id}}  {{program.idPurpose}}
+        + id (string, required) - {{program.id}}  {{program.idPurpose}} {{whitespace.id}}
         + name (string, required) - {{program.name}}
         + currency (string, required) - {{currency.code}}
         + discount (boolean, optional) - {{program.discount}}

--- a/apiary-sources/endpoints/programs-issuances-create.md
+++ b/apiary-sources/endpoints/programs-issuances-create.md
@@ -10,7 +10,7 @@ An Issuance creates many [Values](#reference/0/values) in bulk and is tracked fo
             {{header.authorization}}
 
     + Attributes
-        + id (string, required) - {{issuance.id}}  {{issuance.idPurpose}}
+        + id (string, required) - {{issuance.id}}  {{issuance.idPurpose}} {{whitespace.id}}
         + name (string, required) - {{issuance.name}}
         + count (number, required) - {{issuance.count}}
         + generateCode (CodeGeneration, optional) - {{issuance.generateCode}}

--- a/apiary-sources/endpoints/transactions-checkout.md
+++ b/apiary-sources/endpoints/transactions-checkout.md
@@ -24,7 +24,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
             {{header.authorization}}
 
     + Attributes
-        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
+        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}} {{whitespace.id}}
         + currency (string, required) - {{currency.code}}
         + lineItems (array[LineItem], required)
         + sources (array[LightrailTransactionParty, StripeTransactionParty, InternalTransactionParty], required) - An array of payment sources to use for the checkout transaction. Supported payment rails: `lightrail`, `stripe`, `internal`.

--- a/apiary-sources/endpoints/transactions-credit.md
+++ b/apiary-sources/endpoints/transactions-credit.md
@@ -9,7 +9,7 @@ Credit (add an amount to) a Lightrail payment destination.
             {{header.authorization}}
         
     + Attributes
-        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
+        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}} {{whitespace.id}}
         + destination (LightrailTransactionParty, required) - The rail to credit.  Only `lightrail` rails that refer to a specific Value are supported.
         + currency (string, required) - {{currency.code}}
         + amount (number, optional) - The amount to credit.  Must be > 0 if specified.  One of `amount` or `uses` must be specified.

--- a/apiary-sources/endpoints/transactions-debit.md
+++ b/apiary-sources/endpoints/transactions-debit.md
@@ -9,7 +9,7 @@ Debit (remove an amount from) a Lightrail payment source.  Debiting is simpler a
             {{header.authorization}}
         
     + Attributes
-        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
+        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}} {{whitespace.id}}
         + source (LightrailTransactionParty, required) - The payment rail to debit.  Only `lightrail` rails that refer to a specific Value are supported.
         + currency (string, required) - {{currency.code}}
         + amount (number) - The amount to debit.  Must be > 0 if specified.  One of `amount` or `uses` must be specified.

--- a/apiary-sources/endpoints/transactions-pending-capture.md
+++ b/apiary-sources/endpoints/transactions-pending-capture.md
@@ -13,7 +13,7 @@ Capturing a pending Transaction is not possible when one of the Values is frozen
             {{header.authorization}}
             
     + Attributes
-        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
+        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}} {{whitespace.id}}
         + metadata (object, optional) - {{transaction.metadata}}
         
     + Body

--- a/apiary-sources/endpoints/transactions-pending-void.md
+++ b/apiary-sources/endpoints/transactions-pending-void.md
@@ -11,7 +11,7 @@ Releases a pending Transaction and adds the void to the [Transaction Chain](#ref
             {{header.authorization}}
 
     + Attributes
-        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
+        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}} {{whitespace.id}}
         + metadata (object, optional) - {{transaction.metadata}}
         
     + Body

--- a/apiary-sources/endpoints/transactions-reverse.md
+++ b/apiary-sources/endpoints/transactions-reverse.md
@@ -13,7 +13,7 @@ Reversing a Transaction is not possible when: the Transaction is pending (must b
             {{header.authorization}}
 
     + Attributes
-        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
+        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}} {{whitespace.id}}
         + metadata (object, optional) - {{transaction.metadata}}
      
     + Body

--- a/apiary-sources/endpoints/transactions-transfer.md
+++ b/apiary-sources/endpoints/transactions-transfer.md
@@ -9,7 +9,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
             {{header.authorization}}
 
     + Attributes
-        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}}
+        + id (string, required) - {{transaction.id}}  {{transaction.idPurpose}} {{whitespace.id}}
         + source (LightrailTransactionParty, StripeTransactionParty, required) - The payment rail to debit.  Must be a `stripe` or `lightrail` rail that refers to a specific Value.
         + destination (LightrailTransactionParty, required) - The payment rail to credit. Must refer to a single `lightrail` Value.
         + amount (number, required) - The amount to transfer, > 0.

--- a/apiary-sources/endpoints/values-changeCode.md
+++ b/apiary-sources/endpoints/values-changeCode.md
@@ -9,7 +9,7 @@
             {{header.authorization}}
 
     + Attributes
-        + code (string, optional) - {{value.code}}
+        + code (string, optional) - {{value.code}} {{whitespace.code}}
         + generateCode (CodeGeneration, optional) - {{value.generateCode}}
         
         

--- a/apiary-sources/endpoints/values-create.md
+++ b/apiary-sources/endpoints/values-create.md
@@ -11,10 +11,10 @@
             {{header.authorization}}
 
     + Attributes
-        + id (string, required) - {{value.id}}  {{value.idPurpose}}
+        + id (string, required) - {{value.id}}  {{value.idPurpose}} {{whitespace.id}}
         + programId (string, optional) - {{value.create.programId}}
         + contactId (string, optional) - {{value.create.contactId}}
-        + code (string, optional) - {{value.create.code}}
+        + code (string, optional) - {{value.create.code}} {{whitespace.code}} {{whitespace.valueCodeNote}}
         + isGenericCode (boolean) - {{value.isGenericCode}}
         + genericCodeOptions (GenericCodeOptions, optional)
         + generateCode (CodeGeneration, optional) - {{value.generateCode}}

--- a/apiary-sources/endpoints/values-get.md
+++ b/apiary-sources/endpoints/values-get.md
@@ -19,7 +19,7 @@
 ### Get a Value by Code [GET /values{?code}{?showCode}]
 
 + Parameter
-    + code (string) - the code (secret or generic) of the Value to get.
+    + code (string) - the code (secret or generic) of the Value to get. {{whitespace.valueCodeNote}}
     + showCode (boolean, optional) - {{value.showCode}}
 
 + Request (application/json)

--- a/apiary-sources/metadata.yaml
+++ b/apiary-sources/metadata.yaml
@@ -169,3 +169,7 @@ webhook:
   events: "List of comma-separated events. The `'*'` wild card is supported: for example, use `'*'` to match all events or use `'lightrail.value.*'` to match all Value related events. You can view the full list of supported event types [here](https://www.lightrail.com/docs/#webhooks/supported-event-types)."
   active: "If false, the Webhook will not send events."
   createdBy: "The ID of the user who created the webhook."
+whitespace:
+  id: "IDs may not contain leading or trailing whitespace."
+  code: "Codes may not contain leading or trailing whitespace."
+  valueCodeNote: "As a convenience, leading/trailing whitespace will be trimmed from codes supplied for lookup or for charging in a Transaction."

--- a/apiary.apib
+++ b/apiary.apib
@@ -136,7 +136,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
             Authorization: Bearer <API_KEY>
         
     + Attributes
-        + id (string, required) - The ID you choose to represent the Contact.  Two Contacts can't have the same ID, guaranteeing repeated calls won't create extra resources.  We recommend not using email addresses as IDs because users can change email addresses but the ID can't be changed.
+        + id (string, required) - The ID you choose to represent the Contact.  Two Contacts can't have the same ID, guaranteeing repeated calls won't create extra resources.  We recommend not using email addresses as IDs because users can change email addresses but the ID can't be changed. IDs may not contain leading or trailing whitespace.
         + firstName (string, optional) - The Contact's first name.
         + lastName (string, optional) - The Contact's last name.
         + email (string, optional) - The Contact's email.
@@ -144,14 +144,14 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"0a0fe50d-a688-4ba1-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
+            {"id":"97df5ac2-5ac6-4ada-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"}}
     
 + Response 201 (application/json)
     + Attributes (Contact)
 
     + Body
             
-            {"id":"0a0fe50d-a688-4ba1-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"97df5ac2-5ac6-4ada-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Get a Contact [GET /contacts/{id}]
 
 + Parameter
@@ -167,7 +167,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            {"id":"0a0fe50d-a688-4ba1-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"97df5ac2-5ac6-4ada-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 ### List Contacts [GET /contacts{?limit}{?id}{?firstName}{?lastName}{?email}{?valueId}]
         
@@ -195,7 +195,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
 
-            [{"id":"0a0fe50d-a688-4ba1-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"97df5ac2-5ac6-4ada-a","firstName":"Jeffrey","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino"},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 ### Update a Contact [PATCH /contacts/{id}]
             
 + Parameter
@@ -225,7 +225,7 @@ Values can be [attached](#reference/0/contacts/attach-a-contact-to-a-value) to C
 
     + Body
             
-            {"id":"0a0fe50d-a688-4ba1-a","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"97df5ac2-5ac6-4ada-a","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Delete a Contact [DELETE /contacts/{id}]
 
 + Parameter
@@ -277,7 +277,7 @@ If attaching a Unique Value (`isGenericCode=false`) the Value's `contactId` will
 
     + Body
 
-            {"valueId":"8c3bc9d1-c584-414c-b"}
+            {"valueId":"aaf86ef5-2a72-4ec0-8"}
     
 + Response 200 (application/json)
     
@@ -285,7 +285,7 @@ If attaching a Unique Value (`isGenericCode=false`) the Value's `contactId` will
 
     + Body
             
-            {"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"contactId":"0a0fe50d-a688-4ba1-a","code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","updatedContactIdDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"contactId":"97df5ac2-5ac6-4ada-a","code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","updatedContactIdDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Response 409 (application/json)
     
@@ -343,7 +343,7 @@ If attaching a Unique Value (`isGenericCode=false`) the Value's `contactId` will
 
     + Body
 
-            {"valueId":"8c3bc9d1-c584-414c-b"}
+            {"valueId":"aaf86ef5-2a72-4ec0-8"}
     
 + Response 200 (application/json)
     
@@ -351,7 +351,7 @@ If attaching a Unique Value (`isGenericCode=false`) the Value's `contactId` will
 
     + Body
             
-            {"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"contactId":null,"code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:20.000Z","updatedContactIdDate":"2020-04-27T18:43:20.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"contactId":null,"code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:46.000Z","updatedContactIdDate":"2020-07-14T18:43:46.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Response 409 (application/json)
     
@@ -415,7 +415,7 @@ If attaching a Unique Value (`isGenericCode=false`) the Value's `contactId` will
 
     + Body
 
-            [{"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"contactId":"0a0fe50d-a688-4ba1-a","code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","updatedContactIdDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"contactId":"97df5ac2-5ac6-4ada-a","code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","updatedContactIdDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 
 ## Values [/values]
 
@@ -436,10 +436,10 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
             Authorization: Bearer <API_KEY>
 
     + Attributes
-        + id (string, required) - The ID you choose to represent the Value.  Two Values can't have the same ID, guaranteeing repeated calls won't create extra resources.
+        + id (string, required) - The ID you choose to represent the Value.  Two Values can't have the same ID, guaranteeing repeated calls won't create extra resources. IDs may not contain leading or trailing whitespace.
         + programId (string, optional) - Create as part of a Program and copy default properties from it.
         + contactId (string, optional) - Directly attach to a Contact.
-        + code (string, optional) - Assign a code.
+        + code (string, optional) - Assign a code. Codes may not contain leading or trailing whitespace. As a convenience, leading/trailing whitespace will be trimmed from codes supplied for lookup or for charging in a Transaction.
         + isGenericCode (boolean) - If `true` the code is to be shared publicly and not secret. If `false` the code is treated as a secret. Defaults to false if not provided.
         + genericCodeOptions (GenericCodeOptions, optional)
         + generateCode (CodeGeneration, optional) - Parameters to generate a unique code. The code generated will be stored securely. We recommend using the default length and character set. To do so, simply set to an empty object. ie `generateCode: {}`.
@@ -460,14 +460,14 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
         
     + Body
     
-            {"id":"8c3bc9d1-c584-414c-b","programId":"bc840f91-c6d5-49cc-8","balance":500}
+            {"id":"aaf86ef5-2a72-4ec0-8","programId":"2fe1e4e1-1936-4b3e-b","balance":500}
     
 + Response 201 (application/json)
     + Attributes (Value)
 
     + Body
     
-            {"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"code":null,"isGenericCode":false,"contactId":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"code":null,"isGenericCode":false,"contactId":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Request (application/json) 
     This is an example of creating a generic code.
@@ -478,13 +478,13 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
     
     + Body
     
-            {"id":"d672b058-5c75-4188-8","currency":"USD","isGenericCode":true,"genericCodeOptions":{"perContact":{"usesRemaining":1}},"balanceRule":{"rule":"500 + value.balanceChange","explanation":"$5 off purchase"}}
+            {"id":"dd614dc1-059d-4925-8","currency":"USD","isGenericCode":true,"genericCodeOptions":{"perContact":{"usesRemaining":1}},"balanceRule":{"rule":"500 + value.balanceChange","explanation":"$5 off purchase"}}
         
 + Response 201 (application/json)
 
     + Body
     
-            {"id":"d672b058-5c75-4188-8","currency":"USD","balance":null,"usesRemaining":null,"programId":null,"issuanceId":null,"code":null,"isGenericCode":true,"genericCodeOptions":{"perContact":{"usesRemaining":1}},"contactId":null,"pretax":false,"active":true,"canceled":false,"frozen":false,"discount":false,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":{"rule":"500 + value.balanceChange","explanation":"$5 off purchase"},"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:28.000Z","updatedDate":"2020-04-27T18:43:28.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"dd614dc1-059d-4925-8","currency":"USD","balance":null,"usesRemaining":null,"programId":null,"issuanceId":null,"code":null,"isGenericCode":true,"genericCodeOptions":{"perContact":{"usesRemaining":1}},"contactId":null,"pretax":false,"active":true,"canceled":false,"frozen":false,"discount":false,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":{"rule":"500 + value.balanceChange","explanation":"$5 off purchase"},"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:53.000Z","updatedDate":"2020-07-14T18:43:53.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Get a Value [GET /values/{id}{?showCode}]
 
 + Parameter
@@ -501,12 +501,12 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"code":null,"isGenericCode":false,"contactId":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"code":null,"isGenericCode":false,"contactId":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 ### Get a Value by Code [GET /values{?code}{?showCode}]
 
 + Parameter
-    + code (string) - the code (secret or generic) of the Value to get.
+    + code (string) - the code (secret or generic) of the Value to get. As a convenience, leading/trailing whitespace will be trimmed from codes supplied for lookup or for charging in a Transaction.
     + showCode (boolean, optional) - Show the full code for the Value.
 
 + Request (application/json)
@@ -519,7 +519,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            [{"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"code":null,"isGenericCode":false,"contactId":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"code":null,"isGenericCode":false,"contactId":null,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 
 ### List Values [GET /values{?limit}{?showCode}{?programId}{?currency}{?contactId}{?isGenericCode}{?balance}{?usesRemaining}{?discount}{?active}{?frozen}{?canceled}{?pretax}{?startDate}{?endDate}{?createdDate}{?updatedDate}]
         
@@ -558,7 +558,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            [{"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"contactId":null,"code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"contactId":null,"code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 
 + Response 200 (text/csv)
 
@@ -610,7 +610,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
     
-            {"id":"8c3bc9d1-c584-414c-b","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"contactId":null,"code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:20.000Z","updatedContactIdDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"aaf86ef5-2a72-4ec0-8","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"contactId":null,"code":null,"isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":true,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:46.000Z","updatedContactIdDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Change a Value's code [POST /values/{id}/changeCode]
 
 + Parameter
@@ -622,7 +622,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
             Authorization: Bearer <API_KEY>
 
     + Attributes
-        + code (string, optional) - The code. Unless `isGenericCode` is set to true the code will be treated as a secret and only the last four digits are displayed with an ellipsis, eg: `…ABCD`.
+        + code (string, optional) - The code. Unless `isGenericCode` is set to true the code will be treated as a secret and only the last four digits are displayed with an ellipsis, eg: `…ABCD`. Codes may not contain leading or trailing whitespace.
         + generateCode (CodeGeneration, optional) - Parameters to generate a unique code. The code generated will be stored securely. We recommend using the default length and character set. To do so, simply set to an empty object. ie `generateCode: {}`.
         
         
@@ -635,7 +635,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            {"id":"ca2cdb1f-4b9e-4dac-a","currency":"USD","balance":500,"usesRemaining":null,"programId":"bc840f91-c6d5-49cc-8","issuanceId":null,"contactId":null,"code":"\u20265C4P","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:25.000Z","updatedDate":"2020-04-27T18:43:25.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"b555fc9d-2902-4815-9","currency":"USD","balance":500,"usesRemaining":null,"programId":"2fe1e4e1-1936-4b3e-b","issuanceId":null,"contactId":null,"code":"\u2026E7UD","isGenericCode":false,"pretax":true,"active":true,"canceled":false,"frozen":false,"discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:50.000Z","updatedDate":"2020-07-14T18:43:50.000Z","updatedContactIdDate":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### List a Value's Transactions [GET /values/{id}/transactions{?limit}{?transactionType}{?createdDate}{?currency}]
 
 + Parameter
@@ -660,7 +660,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            [{"id":"cb1c139d-9f8d-43f8-a","transactionType":"debit","currency":"USD","totals":{"remainder":0},"lineItems":null,"paymentSources":null,"steps":[{"rail":"lightrail","valueId":"1719cc14-5d25-435d-9","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null}],"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"tax":null,"pending":false,"createdDate":"2020-04-27T18:43:21.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"a4c44450-2d0f-4afa-8","transactionType":"debit","currency":"USD","totals":{"remainder":0},"lineItems":null,"paymentSources":null,"steps":[{"rail":"lightrail","valueId":"4daf0a32-485a-4e24-b","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null}],"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"tax":null,"pending":false,"createdDate":"2020-07-14T18:43:46.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 ### List a Value's Attached Contacts [GET /values/{id}/contacts{?limit}{?firstName}{?lastName}{?email}{?valueId}]
 
 + Parameter
@@ -686,7 +686,7 @@ Most Values will be accessed by a code, or attached to a [Contact](#reference/0/
 
     + Body
 
-            [{"id":"0a0fe50d-a688-4ba1-a","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"97df5ac2-5ac6-4ada-a","firstName":"The Dude","lastName":"Lebowski","email":"thedude@example.com","metadata":{"alias":"El Duderino","note":"Into the whole 'brevity thing'"},"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 
 ## Programs [/programs]
 
@@ -702,7 +702,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
             Authorization: Bearer <API_KEY>
         
     + Attributes
-        + id (string, required) - The ID you choose to represent the Program.  
+        + id (string, required) - The ID you choose to represent the Program.   IDs may not contain leading or trailing whitespace.
         + name (string, required) - A human-readable name for the Program.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + discount (boolean, optional) - If true Values created in the Program will be marked as a discount on checkout.
@@ -722,14 +722,14 @@ Programs are most commonly used to define and organize promotion campaigns. For 
         
     + Body
 
-            {"id":"bc840f91-c6d5-49cc-8","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
+            {"id":"2fe1e4e1-1936-4b3e-b","name":"Spring Promotion USD","currency":"USD","pretax":true,"discount":true,"fixedInitialBalances":[500]}
     
 + Response 201 (application/json)
     + Attributes (Program)
 
     + Body
             
-            {"id":"bc840f91-c6d5-49cc-8","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"2fe1e4e1-1936-4b3e-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Get a Program [GET /programs/{id}]
 
 + Parameter
@@ -745,7 +745,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-                {"id":"bc840f91-c6d5-49cc-8","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+                {"id":"2fe1e4e1-1936-4b3e-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 ### List Programs [GET /programs{?limit}{?id}{?currency}{?startDate}{?endDate}{?createdDate}{?updatedDate}]
         
@@ -774,7 +774,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
 
-            [{"id":"bc840f91-c6d5-49cc-8","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"2fe1e4e1-1936-4b3e-b","name":"Spring Promotion USD","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 ### Update a Program [PATCH /programs/{id}]
 
 + Parameter
@@ -814,7 +814,7 @@ Programs are most commonly used to define and organize promotion campaigns. For 
 
     + Body
             
-            {"id":"bc840f91-c6d5-49cc-8","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-04-27T18:43:19.000Z","updatedDate":"2020-04-27T18:43:19.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"2fe1e4e1-1936-4b3e-b","name":"Spring Promo US Dollars","currency":"USD","discount":true,"discountSellerLiability":null,"discountSellerLiabilityRule":null,"pretax":true,"active":true,"minInitialBalance":null,"maxInitialBalance":null,"fixedInitialBalances":[500],"fixedInitialUsesRemaining":null,"redemptionRule":null,"balanceRule":null,"startDate":null,"endDate":null,"metadata":null,"createdDate":"2020-07-14T18:43:45.000Z","updatedDate":"2020-07-14T18:43:45.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Delete a Program [DELETE /programs/{id}]
 
 + Parameter
@@ -858,7 +858,7 @@ An Issuance creates many [Values](#reference/0/values) in bulk and is tracked fo
             Authorization: Bearer <API_KEY>
 
     + Attributes
-        + id (string, required) - The ID you choose to represent the Issuance.  Two Issuances can't have the same ID, guaranteeing repeated calls won't create extra resources.
+        + id (string, required) - The ID you choose to represent the Issuance.  Two Issuances can't have the same ID, guaranteeing repeated calls won't create extra resources. IDs may not contain leading or trailing whitespace.
         + name (string, required) - A human-readable name for the Issuance.
         + count (number, required) - The numbers of Values to issue. Must be between 1-1000.
         + generateCode (CodeGeneration, optional) - This will cause each Value created in the Issuance to have its own unique generated code. The code generated will be stored securely. We recommend using the default length and character set. To do so, simply set to an empty object. ie `generateCode: {}`.
@@ -874,14 +874,14 @@ An Issuance creates many [Values](#reference/0/values) in bulk and is tracked fo
         
     + Body
     
-            {"id":"66f8cda8-d9e6-43c7-a","name":"My First Issuance","count":10,"generateCode":{},"balance":500}
+            {"id":"6186e66b-5c00-4daf-b","name":"My First Issuance","count":10,"generateCode":{},"balance":500}
     
 + Response 201 (application/json)
     + Attributes (Issuance)
 
     + Body
     
-            {"id":"66f8cda8-d9e6-43c7-a","name":"My First Issuance","programId":"bc840f91-c6d5-49cc-8","count":10,"balance":500,"redemptionRule":null,"balanceRule":null,"usesRemaining":null,"active":true,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:25.000Z","updatedDate":"2020-04-27T18:43:25.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"6186e66b-5c00-4daf-b","name":"My First Issuance","programId":"2fe1e4e1-1936-4b3e-b","count":10,"balance":500,"redemptionRule":null,"balanceRule":null,"usesRemaining":null,"active":true,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:51.000Z","updatedDate":"2020-07-14T18:43:51.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Get an Issuance [GET /programs/{programId}/issuances/{issuanceId}]
 
 + Parameter
@@ -898,7 +898,7 @@ An Issuance creates many [Values](#reference/0/values) in bulk and is tracked fo
 
     + Body
 
-            {"id":"66f8cda8-d9e6-43c7-a","name":"My First Issuance","programId":"bc840f91-c6d5-49cc-8","count":10,"balance":500,"redemptionRule":null,"balanceRule":null,"usesRemaining":null,"active":true,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:25.000Z","updatedDate":"2020-04-27T18:43:25.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"6186e66b-5c00-4daf-b","name":"My First Issuance","programId":"2fe1e4e1-1936-4b3e-b","count":10,"balance":500,"redemptionRule":null,"balanceRule":null,"usesRemaining":null,"active":true,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:51.000Z","updatedDate":"2020-07-14T18:43:51.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 ### List Issuances [GET /programs/{id}/issuances]
 
@@ -916,7 +916,7 @@ An Issuance creates many [Values](#reference/0/values) in bulk and is tracked fo
 
     + Body
     
-            [{"id":"66f8cda8-d9e6-43c7-a","name":"My First Issuance","programId":"bc840f91-c6d5-49cc-8","count":10,"balance":500,"redemptionRule":null,"balanceRule":null,"usesRemaining":null,"active":true,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-04-27T18:43:25.000Z","updatedDate":"2020-04-27T18:43:25.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"6186e66b-5c00-4daf-b","name":"My First Issuance","programId":"2fe1e4e1-1936-4b3e-b","count":10,"balance":500,"redemptionRule":null,"balanceRule":null,"usesRemaining":null,"active":true,"startDate":null,"endDate":null,"metadata":{},"createdDate":"2020-07-14T18:43:51.000Z","updatedDate":"2020-07-14T18:43:51.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 
 ## Transactions [/transactions]
 
@@ -950,7 +950,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
             Authorization: Bearer <API_KEY>
 
     + Attributes
-        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
+        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice. IDs may not contain leading or trailing whitespace.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + lineItems (array[LineItem], required)
         + sources (array[LightrailTransactionParty, StripeTransactionParty, InternalTransactionParty], required) - An array of payment sources to use for the checkout transaction. Supported payment rails: `lightrail`, `stripe`, `internal`.
@@ -962,7 +962,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
         
     + Body 
     
-            {"id":"f68e4b08-bfec-41cc-9","sources":[{"rail":"lightrail","contactId":"0a0fe50d-a688-4ba1-a"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
+            {"id":"25052bff-490c-4a1d-9","sources":[{"rail":"lightrail","contactId":"97df5ac2-5ac6-4ada-a"},{"rail":"stripe","source":"tok_visa"}],"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05},{"productId":"shipping","unitPrice":349,"taxRate":0.0}],"currency":"USD"}
     
 + Response 201 (application/json)
 
@@ -970,7 +970,7 @@ Error responses: If using the `stripe` rail, it is possible for checkout transac
 
     + Body
     
-            {"id":"f68e4b08-bfec-41cc-9","transactionType":"checkout","currency":"USD","createdDate":"2020-04-27T18:43:21.000Z","tax":{"roundingMode":"HALF_EVEN"},"totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0,"forgiven":0,"discountLightrail":200,"paidLightrail":1000,"paidStripe":422,"paidInternal":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"dc4b0904-d1c9-4d91-8","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":null,"balanceChange":-200,"balanceAfter":null,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"lightrail","valueId":"6f01b475-85db-4473-b","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":1000,"balanceChange":-1000,"balanceAfter":0,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"stripe","chargeId":"ch_1GcbvKCM9MOvFvZKLtgau3yj","charge":{"id":"ch_1GcbvKCM9MOvFvZKLtgau3yj","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1GcbvKCM9MOvFvZKLyQUneIk","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"calculated_statement_descriptor":"Stripe","captured":true,"created":1588013002,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"disputed":false,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"f68e4b08-bfec-41cc-9","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"dc4b0904-d1c9-4d91-8\"},{\"rail\":\"lightrail\",\"valueId\":\"6f01b475-85db-4473-b\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":51,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":null,"payment_method":"card_1GcbvKCM9MOvFvZKgJL8fg2W","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":4,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","installments":null,"last4":"4242","network":"visa","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_1BOVE6CM9MOvFvZK/ch_1GcbvKCM9MOvFvZKLtgau3yj/rcpt_HAxrz9L0VOCfkYVRatIPct9Is5Oyqyn","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1GcbvKCM9MOvFvZKLtgau3yj/refunds"},"review":null,"shipping":null,"source":{"id":"card_1GcbvKCM9MOvFvZKgJL8fg2W","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":4,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"statement_descriptor_suffix":null,"status":"succeeded","transfer_data":null,"transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"0a0fe50d-a688-4ba1-a"},{"rail":"stripe","source":"tok_visa"}],"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"25052bff-490c-4a1d-9","transactionType":"checkout","currency":"USD","createdDate":"2020-07-14T18:43:47.000Z","tax":{"roundingMode":"HALF_EVEN"},"totals":{"subtotal":1548,"tax":74,"discount":200,"payable":1422,"remainder":0,"forgiven":0,"discountLightrail":200,"paidLightrail":1000,"paidStripe":422,"paidInternal":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"steps":[{"rail":"lightrail","valueId":"3016e3a6-b5d1-4fb9-a","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":null,"balanceChange":-200,"balanceAfter":null,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"lightrail","valueId":"ba84cc86-a3d3-4c8e-b","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":1000,"balanceChange":-1000,"balanceAfter":0,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"stripe","chargeId":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","charge":{"id":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1H4t6WCM9MOvFvZKGS41PXxr","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"calculated_statement_descriptor":"Stripe","captured":true,"created":1594752228,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"disputed":false,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"25052bff-490c-4a1d-9","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"3016e3a6-b5d1-4fb9-a\"},{\"rail\":\"lightrail\",\"valueId\":\"ba84cc86-a3d3-4c8e-b\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":11,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":null,"payment_method":"card_1H4t6WCM9MOvFvZKZv1eZb1d","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","installments":null,"last4":"4242","network":"visa","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_1BOVE6CM9MOvFvZK/ch_1H4t6WCM9MOvFvZKMtHiIGtC/rcpt_HeBTnctl0eZccqaLIEPxDtUHJCekJxq","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1H4t6WCM9MOvFvZKMtHiIGtC/refunds"},"review":null,"shipping":null,"source":{"id":"card_1H4t6WCM9MOvFvZKZv1eZb1d","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"statement_descriptor_suffix":null,"status":"succeeded","transfer_data":null,"transfer_group":null},"amount":-422}],"paymentSources":[{"rail":"lightrail","contactId":"97df5ac2-5ac6-4ada-a"},{"rail":"stripe","source":"tok_visa"}],"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Response 409 (application/json)
 
@@ -1024,7 +1024,7 @@ Debit (remove an amount from) a Lightrail payment source.  Debiting is simpler a
             Authorization: Bearer <API_KEY>
         
     + Attributes
-        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
+        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice. IDs may not contain leading or trailing whitespace.
         + source (LightrailTransactionParty, required) - The payment rail to debit.  Only `lightrail` rails that refer to a specific Value are supported.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + amount (number) - The amount to debit.  Must be > 0 if specified.  One of `amount` or `uses` must be specified.
@@ -1036,7 +1036,7 @@ Debit (remove an amount from) a Lightrail payment source.  Debiting is simpler a
 
     + Body
 
-            {"id":"cb1c139d-9f8d-43f8-a","source":{"rail":"lightrail","valueId":"1719cc14-5d25-435d-9"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
+            {"id":"a4c44450-2d0f-4afa-8","source":{"rail":"lightrail","valueId":"4daf0a32-485a-4e24-b"},"amount":1000,"currency":"USD","metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"}}
     
 + Response 201 (application/json)
 
@@ -1044,7 +1044,7 @@ Debit (remove an amount from) a Lightrail payment source.  Debiting is simpler a
 
     + Body
 
-            {"id":"cb1c139d-9f8d-43f8-a","transactionType":"debit","currency":"USD","createdDate":"2020-04-27T18:43:21.000Z","tax":null,"totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1719cc14-5d25-435d-9","contactId":null,"code":null,"balanceBefore":3000,"balanceChange":-1000,"balanceAfter":2000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"a4c44450-2d0f-4afa-8","transactionType":"debit","currency":"USD","createdDate":"2020-07-14T18:43:46.000Z","tax":null,"totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"4daf0a32-485a-4e24-b","contactId":null,"code":null,"balanceBefore":3000,"balanceChange":-1000,"balanceAfter":2000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Response 409 (application/json)
 
@@ -1070,7 +1070,7 @@ Credit (add an amount to) a Lightrail payment destination.
             Authorization: Bearer <API_KEY>
         
     + Attributes
-        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
+        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice. IDs may not contain leading or trailing whitespace.
         + destination (LightrailTransactionParty, required) - The rail to credit.  Only `lightrail` rails that refer to a specific Value are supported.
         + currency (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
         + amount (number, optional) - The amount to credit.  Must be > 0 if specified.  One of `amount` or `uses` must be specified.
@@ -1080,7 +1080,7 @@ Credit (add an amount to) a Lightrail payment destination.
 
     + Body
 
-            {"id":"50e58c00-195a-446c-a","destination":{"rail":"lightrail","valueId":"1719cc14-5d25-435d-9"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
+            {"id":"040bad23-94d6-45d1-9","destination":{"rail":"lightrail","valueId":"4daf0a32-485a-4e24-b"},"amount":2500,"currency":"USD","metadata":{"note":"Frequent buyer bonus"}}
     
 + Response 201 (application/json)
 
@@ -1088,7 +1088,7 @@ Credit (add an amount to) a Lightrail payment destination.
 
     + Body
 
-            {"id":"50e58c00-195a-446c-a","transactionType":"credit","currency":"USD","createdDate":"2020-04-27T18:43:20.000Z","tax":null,"totals":null,"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1719cc14-5d25-435d-9","contactId":null,"code":null,"balanceBefore":500,"balanceChange":2500,"balanceAfter":3000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"note":"Frequent buyer bonus"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"040bad23-94d6-45d1-9","transactionType":"credit","currency":"USD","createdDate":"2020-07-14T18:43:46.000Z","tax":null,"totals":null,"lineItems":null,"steps":[{"rail":"lightrail","valueId":"4daf0a32-485a-4e24-b","contactId":null,"code":null,"balanceBefore":500,"balanceChange":2500,"balanceAfter":3000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"note":"Frequent buyer bonus"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Transfer [POST /transactions/transfer]
 
 Transfer value from a Lightrail or Stripe payment source to a Lightrail payment destination.
@@ -1100,7 +1100,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
             Authorization: Bearer <API_KEY>
 
     + Attributes
-        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
+        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice. IDs may not contain leading or trailing whitespace.
         + source (LightrailTransactionParty, StripeTransactionParty, required) - The payment rail to debit.  Must be a `stripe` or `lightrail` rail that refers to a specific Value.
         + destination (LightrailTransactionParty, required) - The payment rail to credit. Must refer to a single `lightrail` Value.
         + amount (number, required) - The amount to transfer, > 0.
@@ -1111,7 +1111,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
 
     + Body
 
-            {"id":"99e48c2c-8718-42f4-9","source":{"rail":"lightrail","valueId":"ac25d044-a576-443b-b"},"destination":{"rail":"lightrail","valueId":"a6c586c8-14f7-4bec-9"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
+            {"id":"ab8de97a-fcca-4b87-a","source":{"rail":"lightrail","valueId":"ba383328-84ae-46d2-9"},"destination":{"rail":"lightrail","valueId":"d1d90578-c088-47ee-a"},"amount":100,"currency":"USD","metadata":{"reference":"customer request to move funds. ref: #4948173593"}}
 
 + Response 201 (application/json)
 
@@ -1119,7 +1119,7 @@ Transfer value from a Lightrail or Stripe payment source to a Lightrail payment 
 
     + Body
 
-            {"id":"99e48c2c-8718-42f4-9","transactionType":"transfer","currency":"USD","createdDate":"2020-04-27T18:43:25.000Z","tax":null,"totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"ac25d044-a576-443b-b","contactId":null,"code":null,"balanceBefore":500,"balanceChange":-100,"balanceAfter":400,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"lightrail","valueId":"a6c586c8-14f7-4bec-9","contactId":null,"code":null,"balanceBefore":500,"balanceChange":100,"balanceAfter":600,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"reference":"customer request to move funds. ref: #4948173593"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"ab8de97a-fcca-4b87-a","transactionType":"transfer","currency":"USD","createdDate":"2020-07-14T18:43:51.000Z","tax":null,"totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"ba383328-84ae-46d2-9","contactId":null,"code":null,"balanceBefore":500,"balanceChange":-100,"balanceAfter":400,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"lightrail","valueId":"d1d90578-c088-47ee-a","contactId":null,"code":null,"balanceBefore":500,"balanceChange":100,"balanceAfter":600,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"reference":"customer request to move funds. ref: #4948173593"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Response 409 (application/json)
 
@@ -1149,19 +1149,19 @@ Reversing a Transaction is not possible when: the Transaction is pending (must b
             Authorization: Bearer <API_KEY>
 
     + Attributes
-        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
+        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice. IDs may not contain leading or trailing whitespace.
         + metadata (object, optional) - Arbitrary data associated with the Transaction.
      
     + Body
 
-            {"id":"ed1838e3-1e45-4366-a"}
+            {"id":"cf46b73f-70d9-45bb-a"}
 
 + Response 201 (application/json)
     + Attributes (Transaction)
 
     + Body
 
-            {"id":"ed1838e3-1e45-4366-a","transactionType":"reverse","currency":"USD","createdDate":"2020-04-27T18:43:23.000Z","tax":{"roundingMode":"HALF_EVEN"},"totals":{"subtotal":-1548,"tax":-74,"discount":-200,"discountLightrail":-200,"payable":-1422,"paidLightrail":-1000,"paidStripe":-422,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"dc4b0904-d1c9-4d91-8","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":null,"balanceChange":200,"balanceAfter":null,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"lightrail","valueId":"6f01b475-85db-4473-b","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":0,"balanceChange":1000,"balanceAfter":1000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"stripe","chargeId":"ch_1GcbvKCM9MOvFvZKLtgau3yj","charge":{"id":"re_1GcbvMCM9MOvFvZKINs8xm4v","object":"refund","amount":422,"balance_transaction":"txn_1GcbvMCM9MOvFvZKK6pdW2Gc","charge":"ch_1GcbvKCM9MOvFvZKLtgau3yj","created":1588013004,"currency":"usd","metadata":{"reason":"Being refunded as part of reverse transaction ed1838e3-1e45-4366-a."},"payment_intent":null,"reason":null,"receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null},"amount":422}],"paymentSources":null,"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"cf46b73f-70d9-45bb-a","transactionType":"reverse","currency":"USD","createdDate":"2020-07-14T18:43:49.000Z","tax":{"roundingMode":"HALF_EVEN"},"totals":{"subtotal":-1548,"tax":-74,"discount":-200,"discountLightrail":-200,"payable":-1422,"paidLightrail":-1000,"paidStripe":-422,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"3016e3a6-b5d1-4fb9-a","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":null,"balanceChange":200,"balanceAfter":null,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"lightrail","valueId":"ba84cc86-a3d3-4c8e-b","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":0,"balanceChange":1000,"balanceAfter":1000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null},{"rail":"stripe","chargeId":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","charge":{"id":"re_1H4t6XCM9MOvFvZKO7dPgH3K","object":"refund","amount":422,"balance_transaction":"txn_1H4t6XCM9MOvFvZKo9gmAIvB","charge":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","created":1594752229,"currency":"usd","metadata":{"reason":"Being refunded as part of reverse transaction cf46b73f-70d9-45bb-a."},"payment_intent":null,"reason":null,"receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null},"amount":422}],"paymentSources":null,"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Response 409 (application/json)
 
@@ -1205,19 +1205,19 @@ Capturing a pending Transaction is not possible when one of the Values is frozen
             Authorization: Bearer <API_KEY>
             
     + Attributes
-        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
+        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice. IDs may not contain leading or trailing whitespace.
         + metadata (object, optional) - Arbitrary data associated with the Transaction.
         
     + Body
         
-            {"id":"0d4ac1d3-611c-466c-8"}
+            {"id":"8593bea7-2c8c-4443-b"}
         
 + Response 200 (application/json)
     + Attributes (Transaction)
 
     + Body
 
-            {"id":"0d4ac1d3-611c-466c-8","transactionType":"capture","currency":"USD","createdDate":"2020-04-27T18:43:28.000Z","tax":null,"totals":null,"lineItems":null,"steps":[],"paymentSources":null,"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"8593bea7-2c8c-4443-b","transactionType":"capture","currency":"USD","createdDate":"2020-07-14T18:43:53.000Z","tax":null,"totals":null,"lineItems":null,"steps":[],"paymentSources":null,"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 
 + Response 409 (application/json)
 
@@ -1245,19 +1245,19 @@ Releases a pending Transaction and adds the void to the [Transaction Chain](#ref
             Authorization: Bearer <API_KEY>
 
     + Attributes
-        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice.
+        + id (string, required) - The ID you choose to represent the Transaction.  Two Transactions can't have the same ID, guaranteeing the Transaction can't happen twice. IDs may not contain leading or trailing whitespace.
         + metadata (object, optional) - Arbitrary data associated with the Transaction.
         
     + Body
     
-                {"id":"343689d6-5a78-45b8-8"}
+                {"id":"a3878861-0d78-46bf-b"}
 
 + Response 200 (application/json)
     + Attributes (Transaction)
 
     + Body
 
-            {"id":"343689d6-5a78-45b8-8","transactionType":"void","currency":"USD","createdDate":"2020-04-27T18:43:27.000Z","tax":{"roundingMode":"HALF_EVEN"},"totals":{"subtotal":-2576,"tax":-206,"discount":0,"discountLightrail":0,"payable":-2782,"paidLightrail":0,"paidStripe":-2782,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":null,"steps":[{"rail":"stripe","chargeId":"ch_1GcbvPCM9MOvFvZKMHloooOM","charge":{"id":"re_1GcbvQCM9MOvFvZK5r0Wcv4z","object":"refund","amount":2782,"balance_transaction":null,"charge":"ch_1GcbvPCM9MOvFvZKMHloooOM","created":1588013008,"currency":"usd","metadata":{"reason":"not specified"},"payment_intent":null,"reason":null,"receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null},"amount":2782}],"paymentSources":null,"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"a3878861-0d78-46bf-b","transactionType":"void","currency":"USD","createdDate":"2020-07-14T18:43:52.000Z","tax":{"roundingMode":"HALF_EVEN"},"totals":{"subtotal":-2576,"tax":-206,"discount":0,"discountLightrail":0,"payable":-2782,"paidLightrail":0,"paidStripe":-2782,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":null,"steps":[{"rail":"stripe","chargeId":"ch_1H4t6aCM9MOvFvZKe9NwXHjH","charge":{"id":"re_1H4t6bCM9MOvFvZKIFRXDHDp","object":"refund","amount":2782,"balance_transaction":null,"charge":"ch_1H4t6aCM9MOvFvZKe9NwXHjH","created":1594752233,"currency":"usd","metadata":{"reason":"not specified"},"payment_intent":null,"reason":null,"receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null},"amount":2782}],"paymentSources":null,"pending":false,"metadata":null,"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Get a Transaction [GET /transactions/{id}]
 
 + Parameter
@@ -1273,7 +1273,7 @@ Releases a pending Transaction and adds the void to the [Transaction Chain](#ref
 
     + Body
 
-            {"id":"cb1c139d-9f8d-43f8-a","transactionType":"debit","currency":"USD","createdDate":"2020-04-27T18:43:21.000Z","tax":null,"totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"1719cc14-5d25-435d-9","contactId":null,"code":null,"balanceBefore":3000,"balanceChange":-1000,"balanceAfter":2000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"a4c44450-2d0f-4afa-8","transactionType":"debit","currency":"USD","createdDate":"2020-07-14T18:43:46.000Z","tax":null,"totals":{"remainder":0},"lineItems":null,"steps":[{"rail":"lightrail","valueId":"4daf0a32-485a-4e24-b","contactId":null,"code":null,"balanceBefore":3000,"balanceChange":-1000,"balanceAfter":2000,"usesRemainingBefore":null,"usesRemainingChange":null,"usesRemainingAfter":null}],"paymentSources":null,"pending":false,"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
             
 ### Get Transaction Chain [GET /transactions/{id}/chain]
 
@@ -1300,7 +1300,7 @@ A Transaction Chain is an ordered list of Transactions and results from creating
 
     + Body
 
-            [{"id":"f68e4b08-bfec-41cc-9","transactionType":"checkout","currency":"USD","totals":{"subtotal":1548,"tax":74,"discount":200,"discountLightrail":200,"payable":1422,"paidLightrail":1000,"paidStripe":422,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"paymentSources":[{"rail":"lightrail","contactId":"0a0fe50d-a688-4ba1-a"},{"rail":"stripe","source":"tok_visa"}],"steps":[{"rail":"lightrail","valueId":"dc4b0904-d1c9-4d91-8","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":null,"balanceAfter":null,"balanceChange":-200,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"lightrail","valueId":"6f01b475-85db-4473-b","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"stripe","amount":-422,"chargeId":"ch_1GcbvKCM9MOvFvZKLtgau3yj","charge":{"id":"ch_1GcbvKCM9MOvFvZKLtgau3yj","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1GcbvKCM9MOvFvZKLyQUneIk","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"calculated_statement_descriptor":"Stripe","captured":true,"created":1588013002,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"disputed":false,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"f68e4b08-bfec-41cc-9","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"dc4b0904-d1c9-4d91-8\"},{\"rail\":\"lightrail\",\"valueId\":\"6f01b475-85db-4473-b\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":51,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":null,"payment_method":"card_1GcbvKCM9MOvFvZKgJL8fg2W","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":4,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","installments":null,"last4":"4242","network":"visa","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_1BOVE6CM9MOvFvZK/ch_1GcbvKCM9MOvFvZKLtgau3yj/rcpt_HAxrz9L0VOCfkYVRatIPct9Is5Oyqyn","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1GcbvKCM9MOvFvZKLtgau3yj/refunds"},"review":null,"shipping":null,"source":{"id":"card_1GcbvKCM9MOvFvZKgJL8fg2W","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":4,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"statement_descriptor_suffix":null,"status":"succeeded","transfer_data":null,"transfer_group":null}}],"metadata":null,"tax":{"roundingMode":"HALF_EVEN"},"pending":false,"createdDate":"2020-04-27T18:43:21.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},{"id":"ed1838e3-1e45-4366-a","transactionType":"reverse","currency":"USD","totals":{"subtotal":-1548,"tax":-74,"discount":-200,"discountLightrail":-200,"payable":-1422,"paidLightrail":-1000,"paidStripe":-422,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":null,"paymentSources":null,"steps":[{"rail":"lightrail","valueId":"dc4b0904-d1c9-4d91-8","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":null,"balanceAfter":null,"balanceChange":200,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"lightrail","valueId":"6f01b475-85db-4473-b","contactId":"0a0fe50d-a688-4ba1-a","code":null,"balanceBefore":0,"balanceAfter":1000,"balanceChange":1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"stripe","amount":422,"chargeId":"ch_1GcbvKCM9MOvFvZKLtgau3yj","charge":{"id":"re_1GcbvMCM9MOvFvZKINs8xm4v","object":"refund","amount":422,"balance_transaction":"txn_1GcbvMCM9MOvFvZKK6pdW2Gc","charge":"ch_1GcbvKCM9MOvFvZKLtgau3yj","created":1588013004,"currency":"usd","metadata":{"reason":"Being refunded as part of reverse transaction ed1838e3-1e45-4366-a."},"payment_intent":null,"reason":null,"receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null}}],"metadata":null,"tax":{"roundingMode":"HALF_EVEN"},"pending":false,"createdDate":"2020-04-27T18:43:23.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"25052bff-490c-4a1d-9","transactionType":"checkout","currency":"USD","totals":{"subtotal":1548,"tax":74,"discount":200,"discountLightrail":200,"payable":1422,"paidLightrail":1000,"paidStripe":422,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":[{"productId":"socks","unitPrice":500,"quantity":2,"taxRate":0.08,"lineTotal":{"subtotal":1000,"taxable":800,"tax":64,"discount":200,"remainder":0,"payable":864}},{"productId":"shipping","unitPrice":349,"taxRate":0,"quantity":1,"lineTotal":{"subtotal":349,"taxable":349,"tax":0,"discount":0,"remainder":0,"payable":349}},{"productId":"chocolate_bar","unitPrice":199,"taxRate":0.05,"quantity":1,"lineTotal":{"subtotal":199,"taxable":199,"tax":10,"discount":0,"remainder":0,"payable":209}}],"paymentSources":[{"rail":"lightrail","contactId":"97df5ac2-5ac6-4ada-a"},{"rail":"stripe","source":"tok_visa"}],"steps":[{"rail":"lightrail","valueId":"3016e3a6-b5d1-4fb9-a","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":null,"balanceAfter":null,"balanceChange":-200,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"lightrail","valueId":"ba84cc86-a3d3-4c8e-b","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":1000,"balanceAfter":0,"balanceChange":-1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"stripe","amount":-422,"chargeId":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","charge":{"id":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","object":"charge","amount":422,"amount_refunded":0,"application":"ca_Bg76g9LV6IsnS40GKfnFrdlAOFohjAtz","application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1H4t6WCM9MOvFvZKGS41PXxr","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"calculated_statement_descriptor":"Stripe","captured":true,"created":1594752228,"currency":"usd","customer":null,"description":null,"destination":null,"dispute":null,"disputed":false,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{"lightrailTransactionId":"25052bff-490c-4a1d-9","lightrailTransactionSources":"[{\"rail\":\"lightrail\",\"valueId\":\"3016e3a6-b5d1-4fb9-a\"},{\"rail\":\"lightrail\",\"valueId\":\"ba84cc86-a3d3-4c8e-b\"}]","lightrailUserId":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":11,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":null,"payment_method":"card_1H4t6WCM9MOvFvZKZv1eZb1d","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","installments":null,"last4":"4242","network":"visa","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_1BOVE6CM9MOvFvZK/ch_1H4t6WCM9MOvFvZKMtHiIGtC/rcpt_HeBTnctl0eZccqaLIEPxDtUHJCekJxq","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1H4t6WCM9MOvFvZKMtHiIGtC/refunds"},"review":null,"shipping":null,"source":{"id":"card_1H4t6WCM9MOvFvZKZv1eZb1d","object":"card","address_city":null,"address_country":null,"address_line1":null,"address_line1_check":null,"address_line2":null,"address_state":null,"address_zip":null,"address_zip_check":null,"brand":"Visa","country":"US","customer":null,"cvc_check":null,"dynamic_last4":null,"exp_month":7,"exp_year":2021,"fingerprint":"vnMoEG5eZVxSMPc7","funding":"credit","last4":"4242","metadata":{},"name":null,"tokenization_method":null},"source_transfer":null,"statement_descriptor":null,"statement_descriptor_suffix":null,"status":"succeeded","transfer_data":null,"transfer_group":null}}],"metadata":null,"tax":{"roundingMode":"HALF_EVEN"},"pending":false,"createdDate":"2020-07-14T18:43:47.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"},{"id":"cf46b73f-70d9-45bb-a","transactionType":"reverse","currency":"USD","totals":{"subtotal":-1548,"tax":-74,"discount":-200,"discountLightrail":-200,"payable":-1422,"paidLightrail":-1000,"paidStripe":-422,"paidInternal":0,"remainder":0,"forgiven":0},"lineItems":null,"paymentSources":null,"steps":[{"rail":"lightrail","valueId":"3016e3a6-b5d1-4fb9-a","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":null,"balanceAfter":null,"balanceChange":200,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"lightrail","valueId":"ba84cc86-a3d3-4c8e-b","contactId":"97df5ac2-5ac6-4ada-a","code":null,"balanceBefore":0,"balanceAfter":1000,"balanceChange":1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null},{"rail":"stripe","amount":422,"chargeId":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","charge":{"id":"re_1H4t6XCM9MOvFvZKO7dPgH3K","object":"refund","amount":422,"balance_transaction":"txn_1H4t6XCM9MOvFvZKo9gmAIvB","charge":"ch_1H4t6WCM9MOvFvZKMtHiIGtC","created":1594752229,"currency":"usd","metadata":{"reason":"Being refunded as part of reverse transaction cf46b73f-70d9-45bb-a."},"payment_intent":null,"reason":null,"receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null}}],"metadata":null,"tax":{"roundingMode":"HALF_EVEN"},"pending":false,"createdDate":"2020-07-14T18:43:49.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 
 ### List Transactions [GET /transactions{?limit}{?transactionType}{?createdDate}{?currency}{?valueId}]
 
@@ -1327,7 +1327,7 @@ A Transaction Chain is an ordered list of Transactions and results from creating
 
     + Body
 
-            [{"id":"cb1c139d-9f8d-43f8-a","transactionType":"debit","currency":"USD","totals":{"remainder":0},"lineItems":null,"paymentSources":null,"steps":[{"rail":"lightrail","valueId":"1719cc14-5d25-435d-9","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null}],"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"tax":null,"pending":false,"createdDate":"2020-04-27T18:43:21.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"a4c44450-2d0f-4afa-8","transactionType":"debit","currency":"USD","totals":{"remainder":0},"lineItems":null,"paymentSources":null,"steps":[{"rail":"lightrail","valueId":"4daf0a32-485a-4e24-b","contactId":null,"code":null,"balanceBefore":3000,"balanceAfter":2000,"balanceChange":-1000,"usesRemainingBefore":null,"usesRemainingAfter":null,"usesRemainingChange":null}],"metadata":{"note":"Reduce loyalty points after 3mo contact inactivity"},"tax":null,"pending":false,"createdDate":"2020-07-14T18:43:46.000Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 
 # Group Advanced
 
@@ -1343,7 +1343,7 @@ A Currency is a unit of money in Lightrail.  It can be a standard currency such 
             Authorization: Bearer <API_KEY>
         
     + Attributes
-        + code (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`.
+        + code (string, required) - Short code for a currency, eg: `USD`, `FUNBUX`. Codes may not contain leading or trailing whitespace.
         + name (string, required) - Long name for the currency, eg: `Dollars`.
         + symbol (number, required) - Currency symbol used for formatting, eg: `$`.
         + decimalPlaces (number, required) - The number of decimal places used in formatting, eg: US Dollars are stored in cents so `decimalPlaces` is `2`.
@@ -1505,7 +1505,7 @@ Webhooks can notify your application when Lightrail events occur. They enable yo
 
     + Body
             
-            {"id":"webhook1","url":"https://example.com/callbackUrl","events":["*"],"createdDate":"2020-04-27T18:43:29.363Z","updatedDate":"2020-04-27T18:43:29.363Z","secrets":[{"id":"f6a53a5a-e44f-4e33-b43c-934a5ab75564","secret":"RDHOPNCFW0V24NVT","createdDate":"2020-04-27T18:43:29.363Z"}],"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST","active":true}
+            {"id":"webhook1","url":"https://example.com/callbackUrl","events":["*"],"createdDate":"2020-07-14T18:43:54.646Z","updatedDate":"2020-07-14T18:43:54.646Z","secrets":[{"id":"70035525-e1bd-4864-8cbe-61552cf900e8","secret":"5C5SBBCCGPEC0QFO","createdDate":"2020-07-14T18:43:54.647Z"}],"createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST","active":true}
 ### Get Webhook [GET /webhooks/{id}]
 + Parameter
     + id (string) - The ID of the webhook.
@@ -1520,7 +1520,7 @@ Webhooks can notify your application when Lightrail events occur. They enable yo
     
     + Body
             
-            {"id":"webhook1","url":"https://example.com/callbackUrl","secrets":[{"id":"f6a53a5a-e44f-4e33-b43c-934a5ab75564","secret":"\u20264NVT","createdDate":"2020-04-27T18:43:29.363Z"}],"events":["*"],"active":true,"createdDate":"2020-04-27T18:43:29.363Z","updatedDate":"2020-04-27T18:43:29.363Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"webhook1","url":"https://example.com/callbackUrl","secrets":[{"id":"70035525-e1bd-4864-8cbe-61552cf900e8","secret":"\u20260QFO","createdDate":"2020-07-14T18:43:54.647Z"}],"events":["*"],"active":true,"createdDate":"2020-07-14T18:43:54.646Z","updatedDate":"2020-07-14T18:43:54.646Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
             
 
 ### List Webhooks [GET /webhooks]
@@ -1535,7 +1535,7 @@ Webhooks can notify your application when Lightrail events occur. They enable yo
    
     + Body
             
-            [{"id":"webhook1","url":"https://example.com/callbackUrl","secrets":[{"id":"f6a53a5a-e44f-4e33-b43c-934a5ab75564","secret":"\u20264NVT","createdDate":"2020-04-27T18:43:29.363Z"}],"events":["*"],"active":true,"createdDate":"2020-04-27T18:43:29.363Z","updatedDate":"2020-04-27T18:43:29.363Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
+            [{"id":"webhook1","url":"https://example.com/callbackUrl","secrets":[{"id":"70035525-e1bd-4864-8cbe-61552cf900e8","secret":"\u20260QFO","createdDate":"2020-07-14T18:43:54.647Z"}],"events":["*"],"active":true,"createdDate":"2020-07-14T18:43:54.646Z","updatedDate":"2020-07-14T18:43:54.646Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}]
 ### Update Webhook [PATCH /webhooks/{id}]
 + Parameter
     + id (string) - The ID of the webhook.
@@ -1559,7 +1559,7 @@ Webhooks can notify your application when Lightrail events occur. They enable yo
 
     + Body
             
-            {"id":"webhook1","url":"https://example.com/callbackUrl","secrets":[{"id":"f6a53a5a-e44f-4e33-b43c-934a5ab75564","secret":"\u20264NVT","createdDate":"2020-04-27T18:43:29.363Z"}],"events":["lightrail.value.*"],"active":true,"createdDate":"2020-04-27T18:43:29.363Z","updatedDate":"2020-04-27T18:43:30.144Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
+            {"id":"webhook1","url":"https://example.com/callbackUrl","secrets":[{"id":"70035525-e1bd-4864-8cbe-61552cf900e8","secret":"\u20260QFO","createdDate":"2020-07-14T18:43:54.647Z"}],"events":["lightrail.value.*"],"active":true,"createdDate":"2020-07-14T18:43:54.646Z","updatedDate":"2020-07-14T18:43:55.094Z","createdBy":"user-c0e4bc89ec714e6199199e8322459e2e-TEST"}
 ### Delete Webhook [DELETE /webhooks/{id}]
 + Parameter
     + id (string) - The ID of the webhook.
@@ -1627,8 +1627,8 @@ Webhooks can notify your application when Lightrail events occur. They enable yo
 ## CodeGeneration (object)
 + length (number, required) - The number of random characters in the code.  This number must be at least 5 to accommodate a reasonable amount of randomness.
 + charset (string, optional) - The set of characters to use for the random part of the code.  Defaults to all numbers and upper case letters.
-+ prefix (string, optional) - Text prepended before the random characters in the code.
-+ suffix (string, optional) - Text appended after the random characters in the code.
++ prefix (string, optional) - Text prepended before the random characters in the code. May not contain leading whitespace.
++ suffix (string, optional) - Text appended after the random characters in the code. May not contain trailing whitespace.
 
 ## Currency (object)
 + code (string) - Short code for a currency, eg: `USD`, `FUNBUX`.
@@ -1752,7 +1752,7 @@ Webhooks can notify your application when Lightrail events occur. They enable yo
 
 ## LightrailTransactionParty (object)
 + rail (string, required) - The payment rail: `lightrail`. Must be used in combination with one of the following identifiers.
-+ code (string) - The code of a Gift Card or Promotion.
++ code (string) - The code of a Gift Card or Promotion. As a convenience, leading/trailing whitespace will be trimmed from codes supplied for lookup or for charging in a Transaction.
 + contactId (string) - A Contact's ID.  This is shorthand for all Values that a Contact is associated with.
 + valueId (string) - A Value's ID.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
- Leading/trailing whitespace not allowed in properties that uniquely identify resources: system IDs, currency codes, value codes
- Special/convenience handling for value codes: trim on lookup & for use in transactions

For some reason the package-lock.json had not previously been committed to this repo. That's been added here. 